### PR TITLE
8302294: Cherry-pick WebKit 615.1 stabilization fixes

### DIFF
--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/heap/BlockDirectory.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/heap/BlockDirectory.cpp
@@ -67,19 +67,17 @@ void BlockDirectory::updatePercentageOfPagedOutPages(SimpleStats& stats)
     // For some reason this can be unsigned char or char on different OSes...
     using MincoreBufferType = std::remove_pointer_t<FunctionTraits<decltype(mincore)>::ArgumentType<2>>;
     static_assert(std::is_same_v<std::make_unsigned_t<MincoreBufferType>, unsigned char>);
-    // pageSize is effectively a constant so this isn't really variable.
-    IGNORE_CLANG_WARNINGS_BEGIN("vla")
-    MincoreBufferType pagedBits[numberOfPagesInMarkedBlock];
-    IGNORE_CLANG_WARNINGS_END
+    Vector<MincoreBufferType, 16> pagedBits(numberOfPagesInMarkedBlock, MincoreBufferType { });
 
     for (auto* handle : m_blocks) {
         if (!handle)
             continue;
 
-        auto markedBlockSizeInBytes = static_cast<size_t>(reinterpret_cast<char*>(handle->end()) - reinterpret_cast<char*>(handle->start()));
+        auto* pageStart = handle->pageStart();
+        auto markedBlockSizeInBytes = handle->backingStorageSize();
         RELEASE_ASSERT(markedBlockSizeInBytes / pageSize <= numberOfPagesInMarkedBlock);
         // We could cache this in bulk (e.g. 25 MB chunks) but we haven't seen any data that it actually matters.
-        auto result = mincore(handle->start(), markedBlockSizeInBytes, pagedBits);
+        auto result = mincore(pageStart, markedBlockSizeInBytes, pagedBits.data());
         RELEASE_ASSERT(!result);
         constexpr unsigned pageIsResidentAndNotCompressed = 1;
         for (unsigned i = 0; i < numberOfPagesInMarkedBlock; ++i)

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/heap/MarkedBlock.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/heap/MarkedBlock.h
@@ -169,6 +169,8 @@ public:
         size_t markCount();
         size_t size();
 
+        size_t backingStorageSize() { return bitwise_cast<uintptr_t>(end()) - bitwise_cast<uintptr_t>(pageStart()); }
+
         bool isAllocated();
 
         bool isLive(HeapVersion markingVersion, HeapVersion newlyAllocatedVersion, bool isMarking, const HeapCell*);
@@ -202,6 +204,7 @@ public:
         void* end() const { return &m_block->atoms()[m_endAtom]; }
         void* atomAt(size_t i) const { return &m_block->atoms()[i]; }
         bool contains(void* p) const { return start() <= p && p < end(); }
+        void* pageStart() const { return &m_block->atoms()[0]; }
 
         void dumpState(PrintStream&);
 

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/parser/Parser.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/parser/Parser.cpp
@@ -1304,7 +1304,8 @@ template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::parseDe
                     wasString = true;
                     break;
                 case BIGINT:
-                    propertyName = &m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+                    propertyName = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+                    failIfFalse(propertyName, "Cannot parse big int property name");
                     break;
                 case OPENBRACKET:
                     next();
@@ -3011,8 +3012,8 @@ parseMethod:
             next();
             break;
         case BIGINT:
-            ident = &m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
-            ASSERT(ident);
+            ident = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+            failIfFalse(ident, "Cannot parse big int property name");
             next();
             break;
         case ESCAPED_KEYWORD:
@@ -3258,8 +3259,8 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseClassFie
                 next();
                 break;
             case BIGINT:
-                ident = &m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
-                ASSERT(ident);
+                ident = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+                failIfFalse(ident, "Cannot parse big int property name");
                 next();
                 break;
             case DOUBLE:
@@ -4516,7 +4517,8 @@ namedProperty:
         return context.createProperty(const_cast<VM&>(m_vm), m_parserArena, propertyName, node, PropertyNode::Constant, SuperBinding::NotNeeded, ClassElementTag::No);
     }
     case BIGINT: {
-        const Identifier* ident = &m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+        const Identifier* ident = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+        failIfFalse(ident, "Cannot parse big int property name");
         next();
 
         if (match(OPENPAREN)) {
@@ -4608,7 +4610,8 @@ template <class TreeBuilder> TreeProperty Parser<LexerType>::parseGetterSetter(T
         numericPropertyName = m_token.m_data.doubleValue;
         next();
     } else if (match(BIGINT)) {
-        stringPropertyName = &m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+        stringPropertyName = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+        failIfFalse(stringPropertyName, "Cannot parse big int property name");
         next();
     } else if (match(OPENBRACKET)) {
         next();

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/parser/ParserArena.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/parser/ParserArena.cpp
@@ -79,15 +79,21 @@ void ParserArena::allocateFreeablePool()
     ASSERT(freeablePool() == pool);
 }
 
-const Identifier& IdentifierArena::makeBigIntDecimalIdentifier(VM& vm, const Identifier& identifier, uint8_t radix)
+const Identifier* IdentifierArena::makeBigIntDecimalIdentifier(VM& vm, const Identifier& identifier, uint8_t radix)
 {
     if (radix == 10)
-        return identifier;
+        return &identifier;
 
     DeferTermination deferScope(vm);
     auto scope = DECLARE_CATCH_SCOPE(vm);
     JSValue bigInt = JSBigInt::parseInt(nullptr, vm, identifier.string(), radix, JSBigInt::ErrorParseMode::ThrowExceptions, JSBigInt::ParseIntSign::Unsigned);
     scope.assertNoException();
+
+    if (bigInt.isEmpty()) {
+        // Handle out-of-memory or other failures by returning null, since
+        // we don't have a global object to throw exceptions to in this scope.
+        return nullptr;
+    }
 
     // FIXME: We are allocating a JSBigInt just to be able to use
     // JSBigInt::tryGetString when radix is not 10.
@@ -106,7 +112,7 @@ const Identifier& IdentifierArena::makeBigIntDecimalIdentifier(VM& vm, const Ide
         heapBigInt = bigInt.asHeapBigInt();
 
     m_identifiers.append(Identifier::fromString(vm, JSBigInt::tryGetString(vm, heapBigInt, 10)));
-    return m_identifiers.last();
+    return &m_identifiers.last();
 }
 
 const Identifier& IdentifierArena::makePrivateIdentifier(VM& vm, ASCIILiteral prefix, unsigned identifier)

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/parser/ParserArena.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/parser/ParserArena.h
@@ -50,7 +50,7 @@ namespace JSC {
         ALWAYS_INLINE const Identifier& makeIdentifierLCharFromUChar(VM&, const UChar* characters, size_t length);
         ALWAYS_INLINE const Identifier& makeIdentifier(VM&, SymbolImpl*);
 
-        const Identifier& makeBigIntDecimalIdentifier(VM&, const Identifier&, uint8_t radix);
+        const Identifier* makeBigIntDecimalIdentifier(VM&, const Identifier&, uint8_t radix);
         const Identifier& makeNumericIdentifier(VM&, double number);
         const Identifier& makePrivateIdentifier(VM&, ASCIILiteral, unsigned);
 

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/IteratorOperations.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/IteratorOperations.cpp
@@ -64,8 +64,11 @@ JSValue iteratorValue(JSGlobalObject* globalObject, JSValue iterResult)
 
 bool iteratorComplete(JSGlobalObject* globalObject, JSValue iterResult)
 {
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue done = iterResult.get(globalObject, globalObject->vm().propertyNames->done);
-    return done.toBoolean(globalObject);
+    RETURN_IF_EXCEPTION(scope, true);
+    RELEASE_AND_RETURN(scope, done.toBoolean(globalObject));
 }
 
 JSValue iteratorStep(JSGlobalObject* globalObject, IterationRecord iterationRecord)

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/MediaTime.cpp
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/MediaTime.cpp
@@ -304,13 +304,10 @@ MediaTime MediaTime::operator*(int32_t rhs) const
         return positiveInfiniteTime();
     }
 
+    if (hasDoubleValue())
+        return MediaTime::createWithDouble(m_timeValueAsDouble * rhs);
+
     MediaTime a = *this;
-
-    if (a.hasDoubleValue()) {
-        a.m_timeValueAsDouble *= rhs;
-        return a;
-    }
-
     while (!safeMultiply(a.m_timeValue, rhs, a.m_timeValue)) {
         if (a.m_timeScale == 1)
             return signum(a.m_timeValue) == signum(rhs) ? positiveInfiniteTime() : negativeInfiniteTime();

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/PlatformHave.h
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/PlatformHave.h
@@ -1313,3 +1313,9 @@
     || PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 160000))
 #define HAVE_LOCKDOWN_MODE_PDF_ADDITIONS 1
 #endif
+
+#if (PLATFORM(GTK) || PLATFORM(WPE)) && defined(__has_include)
+#if __has_include(<gio/gdesktopappinfo.h>)
+#define HAVE_GDESKTOPAPPINFO 1
+#endif
+#endif

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/URLHelpers.cpp
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/URLHelpers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2022 Apple Inc. All rights reserved.
  * Copyright (C) 2018 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -48,7 +48,8 @@ constexpr unsigned urlBytesBufferLength = 2048;
 //    WebKit was compiled.
 // This is only really important for platforms that load an external IDN allowed script list.
 // Not important for the compiled-in one.
-constexpr auto scriptCodeLimit = static_cast<UScriptCode>(256);
+constexpr auto scriptCodeLimit = static_cast<UScriptCode>(255);
+
 
 static uint32_t allowedIDNScriptBits[(scriptCodeLimit + 31) / 32];
 
@@ -116,6 +117,16 @@ template<> bool isLookalikeCharacterOfScriptType<USCRIPT_CANADIAN_ABORIGINAL>(UC
     }
 }
 
+template<> bool isLookalikeCharacterOfScriptType<USCRIPT_THAI>(UChar32 codePoint)
+{
+    switch (codePoint) {
+    case 0x0E01: // THAI CHARACTER KO KAI
+        return true;
+    default:
+        return false;
+    }
+}
+
 template <UScriptCode ScriptType>
 bool isOfScriptType(UChar32 codePoint)
 {
@@ -163,6 +174,20 @@ bool isLookalikeSequence(const std::optional<UChar32>& previousCodePoint, UChar3
         || isLookalikePair(*previousCodePoint, codePoint);
 }
 
+template <>
+bool isLookalikeSequence<USCRIPT_ARABIC>(const std::optional<UChar32>& previousCodePoint, UChar32 codePoint)
+{
+    auto isArabicDiacritic = [](UChar32 codePoint) {
+        return 0x064B <= codePoint && codePoint <= 0x065F;
+    };
+    auto isArabicCodePoint = [](const std::optional<UChar32>& codePoint) {
+        if (!codePoint)
+            return false;
+        return ublock_getCode(*codePoint) == UBLOCK_ARABIC;
+    };
+    return isArabicDiacritic(codePoint) && !isArabicCodePoint(previousCodePoint);
+}
+
 static bool isLookalikeCharacter(const std::optional<UChar32>& previousCodePoint, UChar32 codePoint)
 {
     // This function treats the following as unsafe, lookalike characters:
@@ -176,22 +201,22 @@ static bool isLookalikeCharacter(const std::optional<UChar32>& previousCodePoint
     // slashes into an ASCII solidus. But one of the two callers uses this
     // on characters that have not been processed by ICU, so they are needed here.
 
-    if (!u_isprint(codePoint) || u_isUWhiteSpace(codePoint) || u_hasBinaryProperty(codePoint, UCHAR_DEFAULT_IGNORABLE_CODE_POINT))
+    if (!u_isprint(codePoint)
+        || u_isUWhiteSpace(codePoint)
+        || u_hasBinaryProperty(codePoint, UCHAR_DEFAULT_IGNORABLE_CODE_POINT)
+        || ublock_getCode(codePoint) == UBLOCK_IPA_EXTENSIONS)
         return true;
 
     switch (codePoint) {
     case 0x00BC: /* VULGAR FRACTION ONE QUARTER */
     case 0x00BD: /* VULGAR FRACTION ONE HALF */
     case 0x00BE: /* VULGAR FRACTION THREE QUARTERS */
-    case 0x00ED: /* LATIN SMALL LETTER I WITH ACUTE */
     /* 0x0131 LATIN SMALL LETTER DOTLESS I is intentionally not considered a lookalike character because it is visually distinguishable from i and it has legitimate use in the Turkish language. */
     case 0x01C0: /* LATIN LETTER DENTAL CLICK */
     case 0x01C3: /* LATIN LETTER RETROFLEX CLICK */
     case 0x0237: /* LATIN SMALL LETTER DOTLESS J */
     case 0x0251: /* LATIN SMALL LETTER ALPHA */
     case 0x0261: /* LATIN SMALL LETTER SCRIPT G */
-    case 0x0274: /* LATIN LETTER SMALL CAPITAL N */
-    case 0x027E: /* LATIN SMALL LETTER R WITH FISHHOOK */
     case 0x02D0: /* MODIFIER LETTER TRIANGULAR COLON */
     case 0x0335: /* COMBINING SHORT STROKE OVERLAY */
     case 0x0337: /* COMBINING SHORT SOLIDUS OVERLAY */
@@ -312,7 +337,9 @@ static bool isLookalikeCharacter(const std::optional<UChar32>& previousCodePoint
     default:
         return isLookalikeSequence<USCRIPT_ARMENIAN>(previousCodePoint, codePoint)
             || isLookalikeSequence<USCRIPT_TAMIL>(previousCodePoint, codePoint)
-            || isLookalikeSequence<USCRIPT_CANADIAN_ABORIGINAL>(previousCodePoint, codePoint);
+            || isLookalikeSequence<USCRIPT_CANADIAN_ABORIGINAL>(previousCodePoint, codePoint)
+            || isLookalikeSequence<USCRIPT_THAI>(previousCodePoint, codePoint)
+            || isLookalikeSequence<USCRIPT_ARABIC>(previousCodePoint, codePoint);
     }
 }
 

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/Vector.h
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/Vector.h
@@ -1781,7 +1781,7 @@ struct Mapper {
     using SourceItemType = typename CollectionInspector<SourceType>::SourceItemType;
     using DestinationItemType = typename std::invoke_result<MapFunction, SourceItemType&>::type;
 
-    static Vector<DestinationItemType> map(SourceType source, const MapFunction& mapFunction)
+    static Vector<DestinationItemType> map(const SourceType& source, const MapFunction& mapFunction)
     {
         Vector<DestinationItemType> result;
         // FIXME: Use std::size when available on all compilers.
@@ -1841,7 +1841,7 @@ struct CompactMapper {
     using ResultItemType = typename std::invoke_result<MapFunction, SourceItemType&>::type;
     using DestinationItemType = typename CompactMapTraits<ResultItemType>::ItemType;
 
-    static Vector<DestinationItemType> compactMap(SourceType source, const MapFunction& mapFunction)
+    static Vector<DestinationItemType> compactMap(const SourceType& source, const MapFunction& mapFunction)
     {
         Vector<DestinationItemType> result;
         for (auto& item : source) {
@@ -1860,7 +1860,7 @@ struct CompactMapper<MapFunction, SourceType, typename std::enable_if<std::is_rv
     using ResultItemType = typename std::invoke_result<MapFunction, SourceItemType&&>::type;
     using DestinationItemType = typename CompactMapTraits<ResultItemType>::ItemType;
 
-    static Vector<DestinationItemType> compactMap(SourceType source, const MapFunction& mapFunction)
+    static Vector<DestinationItemType> compactMap(SourceType&& source, const MapFunction& mapFunction)
     {
         Vector<DestinationItemType> result;
         for (auto& item : source) {

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/text/StringImpl.h
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/text/StringImpl.h
@@ -303,7 +303,7 @@ public:
 
     bool is8Bit() const { return m_hashAndFlags & s_hashFlag8BitBuffer; }
     ALWAYS_INLINE const LChar* characters8() const { ASSERT(is8Bit()); return m_data8; }
-    ALWAYS_INLINE const UChar* characters16() const { ASSERT(!is8Bit()); return m_data16; }
+    ALWAYS_INLINE const UChar* characters16() const { ASSERT(!is8Bit() || isEmpty()); return m_data16; }
 
     template<typename CharacterType> const CharacterType* characters() const;
 

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/text/StringView.cpp
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/text/StringView.cpp
@@ -552,4 +552,10 @@ void StringView::setUnderlyingStringImpl(const StringView&)
 
 #endif // not CHECK_STRINGVIEW_LIFETIME
 
+#if !defined(NDEBUG)
+namespace Detail {
+std::atomic<int> wtfStringCopyCount;
+}
+#endif
+
 } // namespace WTF

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/text/StringView.h
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/text/StringView.h
@@ -441,7 +441,7 @@ inline const LChar* StringView::characters8() const
 
 inline const UChar* StringView::characters16() const
 {
-    ASSERT(!is8Bit());
+    ASSERT(!is8Bit() || isEmpty());
     ASSERT(underlyingStringIsValid());
     return static_cast<const UChar*>(m_characters);
 }

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/cache/DOMCache.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/cache/DOMCache.cpp
@@ -99,9 +99,13 @@ void DOMCache::doMatch(RequestInfo&& info, CacheQueryOptions&& options, MatchCal
     if (UNLIKELY(!scriptExecutionContext()))
         return;
 
-    auto requestOrException = requestFromInfo(WTFMove(info), options.ignoreMethod);
+    bool requestValidationFailed = false;
+    auto requestOrException = requestFromInfo(WTFMove(info), options.ignoreMethod, &requestValidationFailed);
     if (requestOrException.hasException()) {
+        if (requestValidationFailed)
         callback(nullptr);
+        else
+            callback(requestOrException.releaseException());
         return;
     }
 
@@ -135,9 +139,13 @@ void DOMCache::matchAll(std::optional<RequestInfo>&& info, CacheQueryOptions&& o
 
     ResourceRequest resourceRequest;
     if (info) {
-        auto requestOrException = requestFromInfo(WTFMove(info.value()), options.ignoreMethod);
+        bool requestValidationFailed = false;
+        auto requestOrException = requestFromInfo(WTFMove(info.value()), options.ignoreMethod, &requestValidationFailed);
         if (requestOrException.hasException()) {
+            if (requestValidationFailed)
             promise.resolve({ });
+            else
+                promise.reject(requestOrException.releaseException());
             return;
         }
         resourceRequest = requestOrException.releaseReturnValue()->resourceRequest();
@@ -218,18 +226,28 @@ private:
     CompletionHandler<void(ExceptionOr<Vector<Record>>&&)> m_callback;
 };
 
-ExceptionOr<Ref<FetchRequest>> DOMCache::requestFromInfo(RequestInfo&& info, bool ignoreMethod)
+ExceptionOr<Ref<FetchRequest>> DOMCache::requestFromInfo(RequestInfo&& info, bool ignoreMethod, bool* requestValidationFailed)
 {
     RefPtr<FetchRequest> request;
     if (std::holds_alternative<RefPtr<FetchRequest>>(info)) {
         request = std::get<RefPtr<FetchRequest>>(info).releaseNonNull();
-        if (request->method() != "GET"_s && !ignoreMethod)
+        if (request->method() != "GET"_s && !ignoreMethod) {
+            if (requestValidationFailed)
+                *requestValidationFailed = true;
             return Exception { TypeError, "Request method is not GET"_s };
-    } else
-        request = FetchRequest::create(*scriptExecutionContext(), WTFMove(info), { }).releaseReturnValue();
+        }
+    } else {
+        auto result = FetchRequest::create(*scriptExecutionContext(), WTFMove(info), { });
+        if (result.hasException())
+            return result.releaseException();
+        request = result.releaseReturnValue();
+    }
 
-    if (!request->url().protocolIsInHTTPFamily())
+    if (!request->url().protocolIsInHTTPFamily()) {
+        if (requestValidationFailed)
+            *requestValidationFailed = true;
         return Exception { TypeError, "Request url is not HTTP/HTTPS"_s };
+    }
 
     return request.releaseNonNull();
 }

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/cache/DOMCache.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/cache/DOMCache.h
@@ -66,7 +66,7 @@ public:
 private:
     DOMCache(ScriptExecutionContext&, String&& name, uint64_t identifier, Ref<CacheStorageConnection>&&);
 
-    ExceptionOr<Ref<FetchRequest>> requestFromInfo(RequestInfo&&, bool ignoreMethod);
+    ExceptionOr<Ref<FetchRequest>> requestFromInfo(RequestInfo&&, bool ignoreMethod, bool* requestValidationFailed = nullptr);
 
     // ActiveDOMObject
     void stop() final;

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/fetch/FetchLoader.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/fetch/FetchLoader.cpp
@@ -95,6 +95,7 @@ void FetchLoader::start(ScriptExecutionContext& context, const FetchRequest& req
     options.dataBufferingPolicy = DataBufferingPolicy::DoNotBufferData;
     options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
     options.navigationPreloadIdentifier = request.navigationPreloadIdentifier();
+    options.contentEncodingSniffingPolicy = ContentEncodingSniffingPolicy::Disable;
 
     ResourceRequest fetchRequest = request.resourceRequest();
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.cpp
@@ -196,7 +196,7 @@ void IDBOpenDBRequest::requestCompleted(const IDBResultData& data)
     if (isContextStopped()) {
         switch (data.type()) {
         case IDBResultType::OpenDatabaseSuccess:
-            connectionProxy().abortOpenAndUpgradeNeeded(data.databaseConnectionIdentifier(), IDBResourceIdentifier::emptyValue());
+            connectionProxy().abortOpenAndUpgradeNeeded(data.databaseConnectionIdentifier(), std::nullopt);
             break;
         case IDBResultType::OpenDatabaseUpgradeNeeded:
             connectionProxy().abortOpenAndUpgradeNeeded(data.databaseConnectionIdentifier(), data.transactionInfo().identifier());

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -632,6 +632,11 @@ void IDBTransaction::dispatchEvent(Event& event)
     m_didDispatchAbortOrCommit = true;
 
     if (isVersionChange()) {
+        if (!m_openDBRequest) {
+            ASSERT(m_isStopped);
+            return;
+        }
+
         m_openDBRequest->versionChangeTransactionDidFinish();
 
         if (event.type() == eventNames().completeEvent) {

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
@@ -269,7 +269,7 @@ void IDBConnectionProxy::completeOperation(const IDBResultData& resultData)
     operation->transitionToComplete(resultData, WTFMove(operation));
 }
 
-void IDBConnectionProxy::abortOpenAndUpgradeNeeded(uint64_t databaseConnectionIdentifier, const IDBResourceIdentifier& transactionIdentifier)
+void IDBConnectionProxy::abortOpenAndUpgradeNeeded(uint64_t databaseConnectionIdentifier, const std::optional<IDBResourceIdentifier>& transactionIdentifier)
 {
     callConnectionOnMainThread(&IDBConnectionToServer::abortOpenAndUpgradeNeeded, databaseConnectionIdentifier, transactionIdentifier);
 }

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
@@ -106,7 +106,7 @@ public:
 
     void connectionToServerLost(const IDBError&);
 
-    void abortOpenAndUpgradeNeeded(uint64_t databaseConnectionIdentifier, const IDBResourceIdentifier& transactionIdentifier);
+    void abortOpenAndUpgradeNeeded(uint64_t databaseConnectionIdentifier, const std::optional<IDBResourceIdentifier>& transactionIdentifier);
 
     void completeOperation(const IDBResultData&);
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp
@@ -487,7 +487,7 @@ void IDBConnectionToServer::databaseConnectionClosed(uint64_t databaseConnection
         m_delegate->databaseConnectionClosed(databaseConnectionIdentifier);
 }
 
-void IDBConnectionToServer::abortOpenAndUpgradeNeeded(uint64_t databaseConnectionIdentifier, const IDBResourceIdentifier& transactionIdentifier)
+void IDBConnectionToServer::abortOpenAndUpgradeNeeded(uint64_t databaseConnectionIdentifier, const std::optional<IDBResourceIdentifier>& transactionIdentifier)
 {
     LOG(IndexedDB, "IDBConnectionToServer::abortOpenAndUpgradeNeeded");
     ASSERT(isMainThread());

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h
@@ -135,7 +135,7 @@ public:
 
     // To be used when an IDBOpenDBRequest gets a new database connection, optionally with a
     // versionchange transaction, but the page is already torn down.
-    void abortOpenAndUpgradeNeeded(uint64_t databaseConnectionIdentifier, const IDBResourceIdentifier& transactionIdentifier);
+    void abortOpenAndUpgradeNeeded(uint64_t databaseConnectionIdentifier, const std::optional<IDBResourceIdentifier>& transactionIdentifier);
 
     void getAllDatabaseNamesAndVersions(const IDBResourceIdentifier&, const ClientOrigin&);
     WEBCORE_EXPORT void didGetAllDatabaseNamesAndVersions(const IDBResourceIdentifier&, Vector<IDBDatabaseNameAndVersion>&&);

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServerDelegate.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServerDelegate.h
@@ -82,7 +82,7 @@ public:
     virtual void establishTransaction(uint64_t databaseConnectionIdentifier, const IDBTransactionInfo&) = 0;
     virtual void databaseConnectionPendingClose(uint64_t databaseConnectionIdentifier) = 0;
     virtual void databaseConnectionClosed(uint64_t databaseConnectionIdentifier) = 0;
-    virtual void abortOpenAndUpgradeNeeded(uint64_t databaseConnectionIdentifier, const IDBResourceIdentifier& transactionIdentifier) = 0;
+    virtual void abortOpenAndUpgradeNeeded(uint64_t databaseConnectionIdentifier, const std::optional<IDBResourceIdentifier>& transactionIdentifier) = 0;
     virtual void didFireVersionChangeEvent(uint64_t databaseConnectionIdentifier, const IDBResourceIdentifier& requestIdentifier, const IndexedDB::ConnectionClosedOnBehalfOfServer) = 0;
     virtual void openDBRequestCancelled(const IDBRequestData&) = 0;
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/server/IDBServer.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/server/IDBServer.cpp
@@ -455,15 +455,16 @@ void IDBServer::databaseConnectionClosed(uint64_t databaseConnectionIdentifier)
         m_uniqueIDBDatabaseMap.remove(database->identifier());
 }
 
-void IDBServer::abortOpenAndUpgradeNeeded(uint64_t databaseConnectionIdentifier, const IDBResourceIdentifier& transactionIdentifier)
+void IDBServer::abortOpenAndUpgradeNeeded(uint64_t databaseConnectionIdentifier, const std::optional<IDBResourceIdentifier>& transactionIdentifier)
 {
     LOG(IndexedDB, "IDBServer::abortOpenAndUpgradeNeeded");
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = m_transactions.get(transactionIdentifier);
-    if (transaction)
+    if (transactionIdentifier) {
+        if (auto transaction = m_transactions.get(*transactionIdentifier))
         transaction->abortWithoutCallback();
+    }
 
     auto databaseConnection = m_databaseConnections.get(databaseConnectionIdentifier);
     if (!databaseConnection)

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/server/IDBServer.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/server/IDBServer.h
@@ -82,7 +82,7 @@ public:
     WEBCORE_EXPORT void establishTransaction(uint64_t databaseConnectionIdentifier, const IDBTransactionInfo&);
     WEBCORE_EXPORT void databaseConnectionPendingClose(uint64_t databaseConnectionIdentifier);
     WEBCORE_EXPORT void databaseConnectionClosed(uint64_t databaseConnectionIdentifier);
-    WEBCORE_EXPORT void abortOpenAndUpgradeNeeded(uint64_t databaseConnectionIdentifier, const IDBResourceIdentifier& transactionIdentifier);
+    WEBCORE_EXPORT void abortOpenAndUpgradeNeeded(uint64_t databaseConnectionIdentifier, const std::optional<IDBResourceIdentifier>& transactionIdentifier);
     WEBCORE_EXPORT void didFireVersionChangeEvent(uint64_t databaseConnectionIdentifier, const IDBResourceIdentifier& requestIdentifier, IndexedDB::ConnectionClosedOnBehalfOfServer);
     WEBCORE_EXPORT void openDBRequestCancelled(const IDBRequestData&);
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
@@ -92,15 +92,6 @@ void MemoryBackingStoreTransaction::addExistingIndex(MemoryIndex& index)
 void MemoryBackingStoreTransaction::indexDeleted(Ref<MemoryIndex>&& index)
 {
     m_indexes.remove(&index.get());
-
-    // If this MemoryIndex belongs to an object store that will not get restored if this transaction aborts,
-    // then we can forget about it altogether.
-    auto& objectStore = index->objectStore();
-    if (auto deletedObjectStore = m_deletedObjectStores.get(objectStore.info().name())) {
-        if (deletedObjectStore != &objectStore)
-            return;
-    }
-
     auto addResult = m_deletedIndexes.add(index->info().name(), nullptr);
     if (addResult.isNewEntry)
         addResult.iterator->value = WTFMove(index);
@@ -124,8 +115,17 @@ void MemoryBackingStoreTransaction::objectStoreDeleted(Ref<MemoryObjectStore>&& 
 {
     ASSERT(m_objectStores.contains(&objectStore.get()));
     m_objectStores.remove(&objectStore.get());
-
     objectStore->deleteAllIndexes(*this);
+
+    // If the store removed is previously added in this transaction, we don't need to
+    // keep it for transaction abort.
+    if (auto addedObjectStore = m_versionChangeAddedObjectStores.take(&objectStore.get())) {
+        // We don't need to track its indexes either.
+        m_deletedIndexes.removeIf([identifier = objectStore->info().identifier()](auto& entry) {
+            return entry.value->objectStore().info().identifier() == identifier;
+        });
+        return;
+    }
 
     auto addResult = m_deletedObjectStores.add(objectStore->info().name(), nullptr);
     if (addResult.isNewEntry)
@@ -216,11 +216,14 @@ void MemoryBackingStoreTransaction::abort()
     m_originalIndexNames.clear();
 
     for (const auto& iterator : m_originalObjectStoreNames)
-        iterator.key->rename(iterator.value);
+        m_backingStore.renameObjectStoreForVersionChangeAbort(*iterator.key, iterator.value);
     m_originalObjectStoreNames.clear();
 
     for (const auto& objectStore : m_versionChangeAddedObjectStores)
         m_backingStore.removeObjectStoreForVersionChangeAbort(*objectStore);
+    m_deletedIndexes.removeIf([&](auto& entry) {
+        return m_versionChangeAddedObjectStores.contains(&entry.value->objectStore());
+    });
     m_versionChangeAddedObjectStores.clear();
 
     for (auto& objectStore : m_deletedObjectStores.values()) {
@@ -261,8 +264,10 @@ void MemoryBackingStoreTransaction::abort()
         }
     }
 
-    for (auto& index : m_deletedIndexes.values())
+    for (auto& index : m_deletedIndexes.values()) {
+        RELEASE_ASSERT(m_backingStore.hasObjectStore(index->info().objectStoreIdentifier()));
         index->objectStore().maybeRestoreDeletedIndex(*index);
+    }
     m_deletedIndexes.clear();
 
     finish();

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.cpp
@@ -310,6 +310,18 @@ IDBError MemoryIDBBackingStore::renameIndex(const IDBResourceIdentifier& transac
     return IDBError { };
 }
 
+void MemoryIDBBackingStore::renameObjectStoreForVersionChangeAbort(MemoryObjectStore& objectStore, const String& oldName)
+{
+    LOG(IndexedDB, "MemoryIDBBackingStore::renameObjectStoreForVersionChangeAbort");
+
+    auto identifier = objectStore.info().identifier();
+    auto currentName = objectStore.info().name();
+    m_objectStoresByName.remove(currentName);
+    m_objectStoresByName.set(oldName, &objectStore);
+    m_databaseInfo->renameObjectStore(identifier, oldName);
+    objectStore.rename(oldName);
+}
+
 void MemoryIDBBackingStore::removeObjectStoreForVersionChangeAbort(MemoryObjectStore& objectStore)
 {
     LOG(IndexedDB, "MemoryIDBBackingStore::removeObjectStoreForVersionChangeAbort");

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h
@@ -46,7 +46,9 @@ public:
     IDBError getOrEstablishDatabaseInfo(IDBDatabaseInfo&) final;
     uint64_t databaseVersion() final;
     void setDatabaseInfo(const IDBDatabaseInfo&);
+    bool hasObjectStore(uint64_t objectStoreIdentifier) { return !!infoForObjectStore(objectStoreIdentifier); }
 
+    void renameObjectStoreForVersionChangeAbort(MemoryObjectStore&, const String& oldName);
     void removeObjectStoreForVersionChangeAbort(MemoryObjectStore&);
     void restoreObjectStoreForVersionChangeAbort(Ref<MemoryObjectStore>&&);
     void handleLowMemoryWarning() final { };

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/mediarecorder/MediaRecorderProvider.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/mediarecorder/MediaRecorderProvider.cpp
@@ -30,6 +30,7 @@
 
 #include "ContentType.h"
 #include "HTMLParserIdioms.h"
+#include "MediaRecorderPrivate.h"
 
 #if PLATFORM(COCOA) && USE(AVFOUNDATION)
 #include "MediaRecorderPrivateAVFImpl.h"

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
@@ -72,21 +72,11 @@ void ArtworkImageLoader::requestImageResource()
 void ArtworkImageLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
 {
     ASSERT_UNUSED(resource, &resource == m_cachedImage);
-    if (m_cachedImage->loadFailedOrCanceled() || m_cachedImage->errorOccurred() || !m_cachedImage->image() || !m_cachedImage->image()->data() || m_cachedImage->image()->data()->isEmpty()) {
+    if (m_cachedImage->loadFailedOrCanceled() || m_cachedImage->errorOccurred() || !m_cachedImage->image()) {
         m_callback(nullptr);
         return;
     }
-    // Sanitize the image by decoding it into a BitmapImage.
-    RefPtr<FragmentedSharedBuffer> bufferToSanitize = m_cachedImage->image()->data();
-    auto bitmapImage = BitmapImage::create();
-    bitmapImage->setData(WTFMove(bufferToSanitize), true);
-    auto imageBuffer = ImageBuffer::create(bitmapImage->size(), RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
-    if (!imageBuffer) {
-        m_callback(nullptr);
-        return;
-    }
-    imageBuffer->context().drawImage(bitmapImage.get(), FloatPoint::zero());
-    m_callback(bitmapImage.ptr());
+    m_callback(m_cachedImage->image());
 }
 
 ExceptionOr<Ref<MediaMetadata>> MediaMetadata::create(ScriptExecutionContext& context, std::optional<MediaMetadataInit>&& init)

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -498,7 +498,7 @@ ExceptionOr<void> SourceBuffer::appendBufferInternal(const unsigned char* data, 
     m_source->openIfInEndedState();
 
     // 4. Run the coded frame eviction algorithm.
-    m_private->evictCodedFrames(size, maximumBufferSize(), m_source->currentTime(), m_source->duration(), m_source->isEnded());
+    m_private->evictCodedFrames(size, maximumBufferSize(), m_source->currentTime(), m_source->isEnded());
 
     // 5. If the buffer full flag equals true, then throw a QuotaExceededError exception and abort these step.
     if (m_private->isBufferFullFor(size, maximumBufferSize())) {

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
@@ -155,8 +155,10 @@ void CanvasCaptureMediaStreamTrack::Source::canvasResized(CanvasBase& canvas)
 void CanvasCaptureMediaStreamTrack::Source::canvasChanged(CanvasBase& canvas, const std::optional<FloatRect>&)
 {
     ASSERT_UNUSED(canvas, m_canvas == &canvas);
+#if ENABLE(WEBGL)
     if (m_canvas->renderingContext() && m_canvas->renderingContext()->needsPreparationForDisplay())
         return;
+#endif
     scheduleCaptureCanvas();
 }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/modern-media-controls/controls/adwaita-layout-traits.js
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/modern-media-controls/controls/adwaita-layout-traits.js
@@ -92,6 +92,11 @@ class AdwaitaLayoutTraits extends LayoutTraits
         return false;
     }
 
+    inheritsBorderRadius()
+    {
+        return false;
+    }
+
     toString()
     {
         const mode = this.isFullscreen ? "Fullscreen" : "Inline";

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/modern-media-controls/controls/ios-inline-media-controls.css
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/modern-media-controls/controls/ios-inline-media-controls.css
@@ -3,7 +3,6 @@
 
 .media-controls.inline.ios:not(.audio) {
     background-color: rgba(0, 0, 0, 0.55);
-    border-radius: inherit;
 }
 
 .media-controls.inline.ios:not(.audio):is(:empty, .shows-start-button, .faded) {

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/modern-media-controls/controls/ios-layout-traits.js
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/modern-media-controls/controls/ios-layout-traits.js
@@ -85,6 +85,11 @@ class IOSLayoutTraits extends LayoutTraits
         return false;
     }
 
+    inheritsBorderRadius()
+    {
+        return true;
+    }
+
     toString()
     {
         return `[IOSLayoutTraits]`;

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/modern-media-controls/controls/layout-traits.js
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/modern-media-controls/controls/layout-traits.js
@@ -102,6 +102,11 @@ class LayoutTraits
     {
         throw "Derived class must implement this function.";
     }
+
+    inheritsBorderRadius()
+    {
+        throw "Derived class must implement this function.";
+    }
 }
 
 LayoutTraits.Mode = {

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/modern-media-controls/controls/macos-layout-traits.js
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/modern-media-controls/controls/macos-layout-traits.js
@@ -92,6 +92,11 @@ class MacOSLayoutTraits extends LayoutTraits
         return true;
     }
 
+    inheritsBorderRadius()
+    {
+        return false;
+    }
+
     toString()
     {
         const mode = this.isFullscreen ? "Fullscreen" : "Inline";

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
@@ -57,7 +57,6 @@
     -webkit-cursor-visibility: inherit;
     position: relative;
     will-change: z-index;
-    border-radius: inherit;
 }
 
 .media-controls-container,
@@ -89,6 +88,11 @@
 
 :host(:-webkit-animating-full-screen-transition) .media-controls {
     display: none;
+}
+
+.media-controls-container:has(.media-controls.inherits-border-radius),
+.media-controls.inherits-border-radius {
+    border-radius: inherit;
 }
 
 .media-controls > *,

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/modern-media-controls/controls/media-controls.js
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/modern-media-controls/controls/media-controls.js
@@ -30,6 +30,9 @@ class MediaControls extends LayoutNode
     {
         super(`<div class="media-controls"></div>`);
 
+        if (layoutTraits?.inheritsBorderRadius())
+            this.element.classList.add("inherits-border-radius");
+
         this._scaleFactor = 1;
         this._shouldCenterControlsVertically = false;
 
@@ -57,12 +60,12 @@ class MediaControls extends LayoutNode
         this.invalidPlacard = new InvalidPlacard(this);
 
         // FIXME: Adwaita layout doesn't have an icon for pip-placard.
-        if (this.layoutTraits.supportsPiP())
+        if (this.layoutTraits?.supportsPiP())
             this.pipPlacard = new PiPPlacard(this);
         else
             this.pipPlacard = null;
 
-        if (this.layoutTraits.supportsAirPlay()) {
+        if (this.layoutTraits?.supportsAirPlay()) {
             this.airplayButton = new AirplayButton(this);
             this.airplayPlacard = new AirplayPlacard(this);
         } else {

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/modern-media-controls/controls/watchos-layout-traits.js
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/modern-media-controls/controls/watchos-layout-traits.js
@@ -85,6 +85,11 @@ class WatchOSLayoutTraits extends LayoutTraits
         return false;
     }
 
+    inheritsBorderRadius()
+    {
+        return false;
+    }
+
     toString()
     {
         return `[WatchOSLayoutTraits]`;

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/streams/ReadableStream.js
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/streams/ReadableStream.js
@@ -48,10 +48,10 @@ function initializeReadableStream(underlyingSource, strategy)
 
     // FIXME: We should introduce https://streams.spec.whatwg.org/#create-readable-stream.
     // For now, we emulate this with underlyingSource with private properties.
-    if (@getByIdDirectPrivate(underlyingSource, "pull") !== @undefined) {
+    if (underlyingSource.@pull !== @undefined) {
         const size = @getByIdDirectPrivate(strategy, "size");
         const highWaterMark = @getByIdDirectPrivate(strategy, "highWaterMark");
-        @setupReadableStreamDefaultController(this, underlyingSource, size, highWaterMark !== @undefined ? highWaterMark : 1, @getByIdDirectPrivate(underlyingSource, "start"), @getByIdDirectPrivate(underlyingSource, "pull"), @getByIdDirectPrivate(underlyingSource, "cancel"));
+        @setupReadableStreamDefaultController(this, underlyingSource, size, highWaterMark !== @undefined ? highWaterMark : 1, underlyingSource.@start, underlyingSource.@pull, underlyingSource.@cancel);
         return this;
     }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/streams/ReadableStreamSource.idl
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/streams/ReadableStreamSource.idl
@@ -30,10 +30,10 @@
     LegacyNoInterfaceObject,
     SkipVTableValidation
 ] interface ReadableStreamSource {
-    [Custom] Promise<undefined> start(ReadableStreamDefaultController controller);
-    [Custom] Promise<undefined> pull(ReadableStreamDefaultController controller);
-    undefined cancel(any reason);
+    [Custom, PrivateIdentifier] Promise<undefined> start(ReadableStreamDefaultController controller);
+    [Custom, PrivateIdentifier] Promise<undefined> pull(ReadableStreamDefaultController controller);
+    [PrivateIdentifier] undefined cancel(any reason);
 
     // Place holder to keep the controller linked to the source.
-    [CachedAttribute, CustomGetter] readonly attribute any controller;
+    [CachedAttribute, CustomGetter, PrivateIdentifier] readonly attribute any controller;
 };

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/webaudio/AudioNodeOutput.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/webaudio/AudioNodeOutput.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2010, Google Inc. All rights reserved.
+ * Copyright (C) 2010-2014 Google Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -229,9 +230,9 @@ void AudioNodeOutput::disable()
     ASSERT(context().isGraphOwner());
 
     if (m_isEnabled) {
+        m_isEnabled = false;
         for (auto& input : m_inputs.keys())
             input->disable(this);
-        m_isEnabled = false;
     }
 }
 
@@ -240,9 +241,9 @@ void AudioNodeOutput::enable()
     ASSERT(context().isGraphOwner());
 
     if (!m_isEnabled) {
+        m_isEnabled = true;
         for (auto& input : m_inputs.keys())
             input->enable(this);
-        m_isEnabled = true;
     }
 }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/websockets/WebSocketDeflater.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/websockets/WebSocketDeflater.cpp
@@ -34,6 +34,7 @@
 #if !PLATFORM(JAVA)
 
 #include "Logging.h"
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/StdLibExtras.h>
 #include <zlib.h>
@@ -80,13 +81,18 @@ bool WebSocketDeflater::addBytes(const uint8_t* data, size_t length)
 
     size_t maxLength = deflateBound(m_stream.get(), length);
     size_t writePosition = m_buffer.size();
-    m_buffer.grow(writePosition + maxLength);
+    CheckedSize bufferSize = maxLength;
+    bufferSize += writePosition;
+    if (bufferSize.hasOverflowed())
+        return false;
+
+    m_buffer.grow(bufferSize.value());
     setStreamParameter(m_stream.get(), data, length, m_buffer.data() + writePosition, maxLength);
     int result = deflate(m_stream.get(), Z_NO_FLUSH);
     if (result != Z_OK || m_stream->avail_in > 0)
         return false;
 
-    m_buffer.shrink(writePosition + maxLength - m_stream->avail_out);
+    m_buffer.shrink(bufferSize.value() - m_stream->avail_out);
     return true;
 }
 
@@ -94,7 +100,12 @@ bool WebSocketDeflater::finish()
 {
     while (true) {
         size_t writePosition = m_buffer.size();
-        m_buffer.grow(writePosition + bufferIncrementUnit);
+        CheckedSize bufferSize = writePosition;
+        bufferSize += bufferIncrementUnit;
+        if (bufferSize.hasOverflowed())
+            return false;
+
+        m_buffer.grow(bufferSize.value());
         size_t availableCapacity = m_buffer.size() - writePosition;
         setStreamParameter(m_stream.get(), 0, 0, m_buffer.data() + writePosition, availableCapacity);
         int result = deflate(m_stream.get(), Z_SYNC_FLUSH);
@@ -147,7 +158,12 @@ bool WebSocketInflater::addBytes(const uint8_t* data, size_t length)
     size_t consumedSoFar = 0;
     while (consumedSoFar < length) {
         size_t writePosition = m_buffer.size();
-        m_buffer.grow(writePosition + bufferIncrementUnit);
+        CheckedSize bufferSize = writePosition;
+        bufferSize += bufferIncrementUnit;
+        if (bufferSize.hasOverflowed())
+            return false;
+
+        m_buffer.grow(bufferSize.value());
         size_t availableCapacity = m_buffer.size() - writePosition;
         size_t remainingLength = length - consumedSoFar;
         setStreamParameter(m_stream.get(), data + consumedSoFar, remainingLength, m_buffer.data() + writePosition, availableCapacity);
@@ -179,7 +195,12 @@ bool WebSocketInflater::finish()
     size_t consumedSoFar = 0;
     while (consumedSoFar < strippedLength) {
         size_t writePosition = m_buffer.size();
-        m_buffer.grow(writePosition + bufferIncrementUnit);
+        CheckedSize bufferSize = writePosition;
+        bufferSize += bufferIncrementUnit;
+        if (bufferSize.hasOverflowed())
+            return false;
+
+        m_buffer.grow(bufferSize.value());
         size_t availableCapacity = m_buffer.size() - writePosition;
         size_t remainingLength = strippedLength - consumedSoFar;
         setStreamParameter(m_stream.get(), strippedFields + consumedSoFar, remainingLength, m_buffer.data() + writePosition, availableCapacity);

--- a/modules/javafx.web/src/main/native/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -292,6 +292,14 @@ bool AXObjectCache::modalElementHasAccessibleContent(Element& element)
             if (auto* axObject = getOrCreate(node)) {
                 if (!axObject->computeAccessibilityIsIgnored())
                     return true;
+
+#if USE(ATSPI)
+                // When using ATSPI, an accessibility object with 'StaticText' role is ignored.
+                // Its content is exposed by its parent.
+                // Treat such elements as having accessible content.
+                if (axObject->roleValue() == AccessibilityRole::StaticText)
+                    return true;
+#endif
             }
 
             // Don't descend into subtrees for non-visible nodes.

--- a/modules/javafx.web/src/main/native/Source/WebCore/accessibility/AccessibilityMenuList.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/accessibility/AccessibilityMenuList.cpp
@@ -44,6 +44,9 @@ Ref<AccessibilityMenuList> AccessibilityMenuList::create(RenderMenuList* rendere
 
 bool AccessibilityMenuList::press()
 {
+    if (!m_renderer)
+        return false;
+
 #if !PLATFORM(IOS_FAMILY)
     auto element = this->element();
     AXObjectCache::AXNotification notification = AXObjectCache::AXPressDidFail;
@@ -88,6 +91,11 @@ void AccessibilityMenuList::addChildren()
 
 bool AccessibilityMenuList::isCollapsed() const
 {
+    // Collapsed is the "default" state, so if the renderer doesn't exist
+    // this makes slightly more sense than returning false.
+    if (!m_renderer)
+        return true;
+
 #if !PLATFORM(IOS_FAMILY)
     auto* renderer = this->renderer();
     return !(is<RenderMenuList>(renderer) && downcast<RenderMenuList>(*renderer).popupIsVisible());

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/JSDOMOperationReturningPromise.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/JSDOMOperationReturningPromise.h
@@ -43,8 +43,10 @@ public:
             if constexpr (shouldThrow != CastedThisErrorBehavior::Assert) {
                 if (UNLIKELY(!thisObject))
                     return rejectPromiseWithThisTypeError(promise.get(), JSClass::info()->className, operationName);
-            } else
+            } else {
+                UNUSED_PARAM(operationName);
                 ASSERT(thisObject);
+            }
 
             ASSERT_GC_OBJECT_INHERITS(thisObject, JSClass::info());
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/JSEventListener.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/JSEventListener.cpp
@@ -185,6 +185,8 @@ void JSEventListener::handleEvent(ScriptExecutionContext& scriptExecutionContext
 
     JSValue handleEventFunction = jsFunction;
 
+    Ref protectedThis { *this };
+
     auto callData = JSC::getCallData(handleEventFunction);
 
     // If jsFunction is not actually a function and this is an EventListener, see if it implements callback interface.
@@ -207,8 +209,6 @@ void JSEventListener::handleEvent(ScriptExecutionContext& scriptExecutionContext
             return;
         }
     }
-
-    Ref<JSEventListener> protectedThis(*this);
 
     MarkedArgumentBuffer args;
     args.append(toJS(lexicalGlobalObject, globalObject, &event));

--- a/modules/javafx.web/src/main/native/Source/WebCore/css/CSSCustomPropertyValue.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/css/CSSCustomPropertyValue.h
@@ -44,7 +44,7 @@ public:
 
     static Ref<CSSCustomPropertyValue> createUnresolved(const AtomString& name, Ref<CSSVariableReferenceValue>&& value)
     {
-        return adoptRef(*new CSSCustomPropertyValue(name, { WTFMove(value) }));
+        return adoptRef(*new CSSCustomPropertyValue(name, VariantValue { std::in_place_type<Ref<CSSVariableReferenceValue>>, WTFMove(value) }));
     }
 
     static Ref<CSSCustomPropertyValue> createUnresolved(const AtomString& name, CSSValueID value)
@@ -56,7 +56,7 @@ public:
 
     static Ref<CSSCustomPropertyValue> createSyntaxAll(const AtomString& name, Ref<CSSVariableData>&& value)
     {
-        return adoptRef(*new CSSCustomPropertyValue(name, { WTFMove(value) }));
+        return adoptRef(*new CSSCustomPropertyValue(name, VariantValue { std::in_place_type<Ref<CSSVariableData>>, WTFMove(value) }));
     }
 
     static Ref<CSSCustomPropertyValue> createSyntaxLength(const AtomString& name, Length value)

--- a/modules/javafx.web/src/main/native/Source/WebCore/css/CSSSelector.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/css/CSSSelector.h
@@ -561,7 +561,7 @@ inline CSSSelector::CSSSelector(const CSSSelector& o)
     } else if (o.m_hasNameWithCase) {
         m_data.m_nameWithCase = o.m_data.m_nameWithCase;
         m_data.m_nameWithCase->ref();
-    } if (o.match() == Tag) {
+    } else if (o.match() == Tag) {
         m_data.m_tagQName = o.m_data.m_tagQName;
         m_data.m_tagQName->ref();
     } else if (o.m_data.m_value) {

--- a/modules/javafx.web/src/main/native/Source/WebCore/css/FontFace.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/css/FontFace.cpp
@@ -40,7 +40,6 @@
 #include "DOMPromiseProxy.h"
 #include "Document.h"
 #include "JSFontFace.h"
-#include "Quirks.h"
 #include "StyleProperties.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <JavaScriptCore/ArrayBufferView.h>
@@ -182,16 +181,10 @@ ExceptionOr<void> FontFace::setFamily(ScriptExecutionContext& context, const Str
     if (family.isEmpty())
         return Exception { SyntaxError };
 
-    String familyNameToUse = family;
-    // FIXME: Quirks currently aren't present on Workers, but should likely be inherited
-    //        from the parent Document where applicable.
-    if (familyNameToUse.contains('\'') && is<Document>(context) && downcast<Document>(context).quirks().shouldStripQuotationMarkInFontFaceSetFamily())
-        familyNameToUse = family.removeCharacters([](auto character) { return character == '\''; });
-
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=196381 Don't use a list here.
     // See consumeFontFamilyDescriptor() in CSSPropertyParser.cpp for why we're using it.
     auto list = CSSValueList::createCommaSeparated();
-    list->append(context.cssValuePool().createFontFamilyValue(familyNameToUse));
+    list->append(context.cssValuePool().createFontFamilyValue(family));
     bool success = m_backing->setFamilies(list);
     if (!success)
         return Exception { SyntaxError };

--- a/modules/javafx.web/src/main/native/Source/WebCore/css/MediaQueryEvaluator.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/css/MediaQueryEvaluator.cpp
@@ -434,7 +434,7 @@ static bool devicePixelRatioEvaluate(CSSValue* value, const CSSToLengthConversio
 
 static bool resolutionEvaluate(CSSValue* value, const CSSToLengthConversionData&, Frame& frame, MediaFeaturePrefix op)
 {
-    if (!frame.settings().resolutionMediaFeatureEnabled() || frame.document()->quirks().shouldDisableResolutionMediaQuery())
+    if (!frame.settings().resolutionMediaFeatureEnabled())
         return false;
 
     return (!value || (is<CSSPrimitiveValue>(*value) && downcast<CSSPrimitiveValue>(*value).isResolution())) && evaluateResolution(value, frame, op);

--- a/modules/javafx.web/src/main/native/Source/WebCore/css/fullscreen.css
+++ b/modules/javafx.web/src/main/native/Source/WebCore/css/fullscreen.css
@@ -25,7 +25,6 @@
 #if defined(ENABLE_FULLSCREEN_API) && ENABLE_FULLSCREEN_API
 
 :-webkit-full-screen {
-    background-color: white;
     z-index: 2147483647 !important;
     width: 100%;
     height: 100%;

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/Document.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/Document.cpp
@@ -827,14 +827,14 @@ void Document::commonTeardown()
     m_documentFragmentForInnerOuterHTML = nullptr;
 
     auto intersectionObservers = m_intersectionObservers;
-    for (auto& intersectionObserver : intersectionObservers) {
-        if (intersectionObserver)
+    for (auto& weakIntersectionObserver : intersectionObservers) {
+        if (RefPtr intersectionObserver = weakIntersectionObserver.get())
             intersectionObserver->disconnect();
     }
 
     auto resizeObservers = m_resizeObservers;
-    for (auto& resizeObserver : resizeObservers) {
-        if (resizeObserver)
+    for (auto& weakResizeObserver : resizeObservers) {
+        if (RefPtr resizeObserver = weakResizeObserver.get())
             resizeObserver->disconnect();
     }
 
@@ -3031,7 +3031,8 @@ ExceptionOr<void> Document::open(Document* entryDocument)
         bool isNavigating = m_frame->loader().policyChecker().delegateIsDecidingNavigationPolicy() || m_frame->loader().state() == FrameState::Provisional || m_frame->navigationScheduler().hasQueuedNavigation();
         if (m_frame->loader().policyChecker().delegateIsDecidingNavigationPolicy())
             m_frame->loader().policyChecker().stopCheck();
-        if (isNavigating)
+        // Null-checking m_frame again as `policyChecker().stopCheck()` may have cleared it.
+        if (isNavigating && m_frame)
             m_frame->loader().stopAllLoaders();
     }
 
@@ -4435,12 +4436,15 @@ void Document::runScrollSteps()
     if (frameView) {
         MonotonicTime now = MonotonicTime::now();
         bool scrollAnimationsInProgress = serviceScrollAnimationForScrollableArea(frameView.get(), now);
-        if (auto* scrollableAreas = frameView->scrollableAreas()) {
-            for (auto* scrollableArea : *scrollableAreas) {
+        HashSet<ScrollableArea*> scrollableAreasToUpdate;
+        if (auto userScrollableAreas = frameView->scrollableAreas())
+            scrollableAreasToUpdate.add(userScrollableAreas->begin(), userScrollableAreas->end());
+        if (auto nonUserScrollableAreas = frameView->scrollableAreasForAnimatedScroll())
+            scrollableAreasToUpdate.add(nonUserScrollableAreas->begin(), nonUserScrollableAreas->end());
+        for (auto* scrollableArea : scrollableAreasToUpdate) {
                 if (serviceScrollAnimationForScrollableArea(scrollableArea, now))
                     scrollAnimationsInProgress = true;
             }
-        }
         if (scrollAnimationsInProgress)
             page()->scheduleRenderingUpdate({ RenderingUpdateStep::Scroll });
     }
@@ -9086,7 +9090,7 @@ void Document::dispatchSystemPreviewActionEvent(const SystemPreviewInfo& systemP
     if (!is<HTMLAnchorElement>(element))
         return;
 
-    if (!element->isConnected() || &element->document() != this)
+    if (&element->document() != this)
         return;
 
     auto event = MessageEvent::create(message, securityOrigin().toString());
@@ -9265,6 +9269,11 @@ bool Document::isSameSiteForCookies(const URL& url) const
 {
     auto domain = isTopDocument() ? RegistrableDomain(securityOrigin().data()) : RegistrableDomain(siteForCookies());
     return domain.matches(url);
+}
+
+bool Document::lazyImageLoadingEnabled() const
+{
+    return m_settings->lazyImageLoadingEnabled() && !m_quirks->shouldDisableLazyImageLoadingQuirk();
 }
 
 } // namespace WebCore

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/Document.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/Document.h
@@ -1693,6 +1693,8 @@ public:
 
     std::optional<PAL::SessionID> sessionID() const final;
 
+    // This should be used over the settings lazy loading image flag due to a quirk, which may occur causing website images to fail to load properly.
+    bool lazyImageLoadingEnabled() const;
 
 protected:
     enum ConstructionFlags { Synthesized = 1, NonRenderedPlaceholder = 1 << 1 };

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -587,6 +587,8 @@ void ApplyStyleCommand::applyInlineStyle(EditingStyle& style)
             splitTextAtStart(start, end);
         start = startPosition();
         end = endPosition();
+        if (start.isNull() || end.isNull())
+            return;
         startDummySpanAncestor = dummySpanAncestorForNode(start.deprecatedNode());
     }
 
@@ -599,6 +601,8 @@ void ApplyStyleCommand::applyInlineStyle(EditingStyle& style)
             splitTextAtEnd(start, end);
         start = startPosition();
         end = endPosition();
+        if (start.isNull() || end.isNull())
+            return;
         endDummySpanAncestor = dummySpanAncestorForNode(end.deprecatedNode());
     }
 
@@ -1256,6 +1260,8 @@ bool ApplyStyleCommand::shouldSplitTextElement(Element* element, EditingStyle& s
 
 bool ApplyStyleCommand::isValidCaretPositionInTextNode(const Position& position)
 {
+    ASSERT(position.isNotNull());
+
     Node* node = position.containerNode();
     if (position.anchorType() != Position::PositionIsOffsetInAnchor || !is<Text>(node))
         return false;

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2005, 2006, 2007, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -608,7 +609,10 @@ void CompositeEditCommand::insertNodeAt(Ref<Node>&& insertChild, const Position&
 
 void CompositeEditCommand::appendNode(Ref<Node>&& node, Ref<ContainerNode>&& parent)
 {
-    ASSERT(canHaveChildrenForEditing(parent));
+    // When cloneParagraphUnderNewElement() clones the fallback content of an OBJECT element,
+    // the ASSERT below may fire since the return value of canHaveChildrenForEditing is not reliable
+    // until the render object of the OBJECT is created. Hence we ignore this check for OBJECTs.
+    ASSERT(canHaveChildrenForEditing(parent) || parent->hasTagName(objectTag));
     applyCommandToComposite(AppendNodeCommand::create(WTFMove(parent), WTFMove(node), editingAction()));
 }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -980,7 +980,7 @@ void DeleteSelectionCommand::doApply()
     if (!m_hasSelectionToDelete)
         m_selectionToDelete = endingSelection();
 
-    if (!m_selectionToDelete.isNonOrphanedRange())
+    if (!m_selectionToDelete.isNonOrphanedRange() || !m_selectionToDelete.isContentEditable())
         return;
 
     String originalString = originalStringForAutocorrectionAtBeginningOfSelection();

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/FrameSelection.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/FrameSelection.cpp
@@ -719,6 +719,14 @@ TextDirection FrameSelection::directionOfSelection()
     return directionOfEnclosingBlock();
 }
 
+static bool selectionIsOrphanedOrBelongsToWrongDocument(const VisibleSelection& selection, RefPtr<Document>&& document)
+{
+    if (selection.isOrphan())
+        return true;
+    RefPtr documentOfSelection = selection.document();
+    return document && documentOfSelection && document != documentOfSelection;
+}
+
 void FrameSelection::willBeModified(EAlteration alter, SelectionDirection direction)
 {
     if (alter != AlterationExtend)
@@ -766,6 +774,8 @@ void FrameSelection::willBeModified(EAlteration alter, SelectionDirection direct
         m_selection.setBase(end);
         m_selection.setExtent(start);
     }
+    if (selectionIsOrphanedOrBelongsToWrongDocument(m_selection, m_document.get()))
+        clear();
 }
 
 VisiblePosition FrameSelection::positionForPlatform(bool isGetStart) const

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/IndentOutdentCommand.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/IndentOutdentCommand.cpp
@@ -118,6 +118,10 @@ void IndentOutdentCommand::indentIntoBlockquote(const Position& start, const Pos
             insertNodeAt(*targetBlockquote, start);
         else if (!insertNodeBefore(*targetBlockquote, *outerBlock))
             return;
+        if (!targetBlockquote->hasEditableStyle()) {
+            removeNode(*targetBlockquote);
+            return;
+        }
         startOfContents = positionInParentAfterNode(targetBlockquote.get());
     }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/InsertListCommand.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/InsertListCommand.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2006, 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2015 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -175,7 +176,7 @@ void InsertListCommand::doApply()
                         // If endOfSelection is null, then some contents have been deleted from the document.
                         // This should never happen and if it did, exit early immediately because we've lost the loop invariant.
                         ASSERT(endOfSelection.isNotNull());
-                        if (endOfSelection.isNull())
+                        if (endOfSelection.isNull() || !endOfSelection.rootEditableElement())
                             return;
                         startOfLastParagraph = startOfParagraph(endOfSelection, CanSkipOverEditingBoundary);
                     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2005-2017 Apple Inc. All rights reserved.
- * Copyright (C) 2009, 2010, 2011 Google Inc. All rights reserved.
+ * Copyright (C) 2009-2022 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -833,6 +833,9 @@ void ReplaceSelectionCommand::moveNodeOutOfAncestor(Node& node, Node& ancestor, 
 {
     Ref<Node> protectedNode = node;
     Ref<Node> protectedAncestor = ancestor;
+
+    if (!protectedAncestor->parentNode()->hasEditableStyle())
+        return;
 
     VisiblePosition positionAtEndOfNode = lastPositionInOrAfterNode(&node);
     VisiblePosition lastPositionInParagraph = lastPositionInNode(&ancestor);

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/markup.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/markup.cpp
@@ -688,19 +688,26 @@ Node* StyledMarkupAccumulator::traverseNodesForSerialization(Node& startNode, No
 
         Vector<Node*, 8> exitedAncestors;
         next = nullptr;
-        if (auto* child = firstChild(*n))
-            next = child;
-        else if (auto* sibling = nextSibling(*n))
+
+        auto advanceToAncestorSibling = [&]() {
+            if (auto* sibling = nextSibling(*n)) {
             next = sibling;
-        else {
+                return;
+            }
             for (auto* ancestor = parentNode(*n); ancestor; ancestor = parentNode(*ancestor)) {
                 exitedAncestors.append(ancestor);
                 if (auto* sibling = nextSibling(*ancestor)) {
                     next = sibling;
-                    break;
-                }
+                    return;
             }
         }
+        };
+
+        if (auto* child = firstChild(*n))
+            next = child;
+        else
+            advanceToAncestorSibling();
+
         ASSERT(next || !pastEnd || n->containsIncludingShadowDOM(pastEnd));
 
         if (isBlock(n) && canHaveChildrenForEditing(*n) && next == pastEnd) {
@@ -709,9 +716,10 @@ Node* StyledMarkupAccumulator::traverseNodesForSerialization(Node& startNode, No
         }
 
         bool didEnterNode = false;
-        if (!enterNode(*n))
-            next = nextSkippingChildren(*n);
-        else if (!hasChildNodes(*n))
+        if (!enterNode(*n)) {
+            exitedAncestors.clear();
+            advanceToAncestorSibling();
+        } else if (!hasChildNodes(*n))
             exitNode(*n);
         else
             didEnterNode = true;

--- a/modules/javafx.web/src/main/native/Source/WebCore/history/CachedPage.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/history/CachedPage.cpp
@@ -78,7 +78,7 @@ CachedPage::~CachedPage()
         m_cachedMainFrame->destroy();
 }
 
-static void firePageShowAndPopStateEvents(Page& page)
+static void firePageShowEvent(Page& page)
 {
     // Dispatching JavaScript events can cause frame destruction.
     auto& mainFrame = page.mainFrame();
@@ -97,10 +97,6 @@ static void firePageShowAndPopStateEvents(Page& page)
         document->setVisibilityHiddenDueToDismissal(false);
 
         document->dispatchPageshowEvent(PageshowEventPersisted);
-
-        auto* historyItem = child->loader().history().currentItem();
-        if (historyItem && historyItem->stateObject())
-            document->dispatchPopstateEvent(historyItem->stateObject());
     }
 }
 
@@ -169,7 +165,7 @@ void CachedPage::restore(Page& page)
             frameView->updateContentsSize();
     }
 
-    firePageShowAndPopStateEvents(page);
+    firePageShowEvent(page);
 
 #if ENABLE(INTELLIGENT_TRACKING_PREVENTION)
     for (auto& domain : m_loadedSubresourceDomains)

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -243,7 +243,7 @@ bool BaseDateAndTimeInputType::shouldRespectListAttribute()
 bool BaseDateAndTimeInputType::valueMissing(const String& value) const
 {
     ASSERT(element());
-    return !element()->isDisabledOrReadOnly() && element()->isRequired() && value.isEmpty();
+    return element()->isMutable() && element()->isRequired() && value.isEmpty();
 }
 
 bool BaseDateAndTimeInputType::isKeyboardFocusable(KeyboardEvent*) const
@@ -288,7 +288,7 @@ void BaseDateAndTimeInputType::setValue(const String& value, bool valueChanged, 
 void BaseDateAndTimeInputType::handleDOMActivateEvent(Event&)
 {
     ASSERT(element());
-    if (element()->isDisabledOrReadOnly() || !element()->renderer() || !UserGestureIndicator::processingUserGesture())
+    if (!element()->isMutable() || !element()->renderer() || !UserGestureIndicator::processingUserGesture())
         return;
 
     if (m_dateTimeChooser)

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/ColorInputType.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/ColorInputType.cpp
@@ -95,9 +95,6 @@ bool ColorInputType::isKeyboardFocusable(KeyboardEvent*) const
 {
     ASSERT(element());
 #if PLATFORM(IOS_FAMILY)
-    if (element()->isReadOnly())
-        return false;
-
     return element()->isTextFormControlFocusable();
 #else
     return false;

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/FileInputType.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/FileInputType.cpp
@@ -31,6 +31,7 @@
 #include "ElementRareData.h"
 #include "Event.h"
 #include "File.h"
+#include "FileChooser.h"
 #include "FileList.h"
 #include "FormController.h"
 #include "Frame.h"
@@ -340,7 +341,7 @@ void FileInputType::applyFileChooserSettings()
     if (m_fileChooser)
         m_fileChooser->invalidate();
 
-    m_fileChooser = FileChooser::create(this, fileChooserSettings());
+    m_fileChooser = FileChooser::create(*this, fileChooserSettings());
 }
 
 bool FileInputType::allowsDirectories() const

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/FormController.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/FormController.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "FormController.h"
 
+#include "FileChooser.h"
 #include "HTMLFormElement.h"
 #include "HTMLInputElement.h"
 #include "ScriptDisallowedScope.h"
@@ -92,8 +93,6 @@ static std::optional<FormControlState> consumeSerializedFormControlState(AtomStr
         return std::nullopt;
     return reader.consumeSubvector(parseInteger<size_t>(sizeString).value_or(0));
 }
-
-// ----------------------------------------------------------------------------
 
 // ----------------------------------------------------------------------------
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLFontElement.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLFontElement.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Simon Hausmann <hausmann@kde.org>
- * Copyright (C) 2003, 2006, 2008, 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2022 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -190,7 +190,7 @@ void HTMLFontElement::collectPresentationalHintsForAttribute(const QualifiedName
             addPropertyToPresentationalHintStyle(style, CSSPropertyFontSize, size);
     } else if (name == colorAttr)
         addHTMLColorToStyle(style, CSSPropertyColor, value);
-    else if (name == faceAttr) {
+    else if (name == faceAttr && !value.isEmpty()) {
         if (auto fontFaceValue = CSSValuePool::singleton().createFontFaceValue(value))
             style.setProperty(CSSProperty(CSSPropertyFontFamily, WTFMove(fontFaceValue)));
     } else

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLFormControlElement.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLFormControlElement.h
@@ -113,8 +113,10 @@ public:
     void updateValidity();
     void setCustomValidity(const String&) override;
 
-    bool isReadOnly() const { return m_isReadOnly; }
-    bool isDisabledOrReadOnly() const { return isDisabledFormControl() || m_isReadOnly; }
+    virtual bool supportsReadOnly() const { return false; }
+    bool isReadOnly() const { return supportsReadOnly() && m_hasReadOnlyAttribute; }
+    bool isMutable() const { return !isDisabledFormControl() && !isReadOnly(); }
+    void updateReadOnlyState();
 
     WEBCORE_EXPORT String autocomplete() const;
     WEBCORE_EXPORT void setAutocomplete(const AtomString&);
@@ -197,7 +199,7 @@ private:
     bool m_isFocusingWithValidationMessage { false };
 
     unsigned m_disabled : 1;
-    unsigned m_isReadOnly : 1;
+    unsigned m_hasReadOnlyAttribute : 1;
     unsigned m_isRequired : 1;
     unsigned m_valueMatchesRenderer : 1;
     unsigned m_disabledByAncestorFieldset : 1;

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLFrameOwnerElement.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLFrameOwnerElement.cpp
@@ -133,7 +133,8 @@ bool HTMLFrameOwnerElement::isProhibitedSelfReference(const URL& completeURL) co
     // We allow one level of self-reference because some websites depend on that, but we don't allow more than one.
     bool foundOneSelfReference = false;
     for (auto* frame = document().frame(); frame; frame = frame->tree().parent()) {
-        if (equalIgnoringFragmentIdentifier(frame->document()->url(), completeURL)) {
+        // Use creationURL() because url() can be changed via History.replaceState() so it's not reliable.
+        if (equalIgnoringFragmentIdentifier(frame->document()->creationURL(), completeURL)) {
             if (foundOneSelfReference)
                 return true;
             foundOneSelfReference = true;

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLImageElement.idl
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLImageElement.idl
@@ -42,7 +42,7 @@
     readonly attribute USVString currentSrc;
     [CEReactions=NotNeeded, EnabledBySetting=ReferrerPolicyAttributeEnabled, ImplementedAs=referrerPolicyForBindings] attribute [AtomString] DOMString referrerPolicy;
     [CEReactions=NotNeeded] attribute [AtomString] DOMString decoding;
-    [CEReactions, EnabledBySetting=LazyImageLoadingEnabled, ImplementedAs=loadingForBindings] attribute [AtomString] DOMString loading;
+    [CEReactions, DisabledByQuirk=shouldDisableLazyImageLoading, EnabledBySetting=LazyImageLoadingEnabled, ImplementedAs=loadingForBindings] attribute [AtomString] DOMString loading;
 
     Promise<undefined> decode();
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLInputElement.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLInputElement.cpp
@@ -44,6 +44,7 @@
 #include "Editor.h"
 #include "ElementInlines.h"
 #include "EventNames.h"
+#include "FileChooser.h"
 #include "FileInputType.h"
 #include "FileList.h"
 #include "FormController.h"
@@ -206,11 +207,6 @@ HTMLElement* HTMLInputElement::innerBlockElement() const
 HTMLElement* HTMLInputElement::innerSpinButtonElement() const
 {
     return m_inputType->innerSpinButtonElement();
-}
-
-HTMLElement* HTMLInputElement::capsLockIndicatorElement() const
-{
-    return m_inputType->capsLockIndicatorElement();
 }
 
 HTMLElement* HTMLInputElement::autoFillButtonElement() const
@@ -543,6 +539,10 @@ void HTMLInputElement::updateType()
     removeFromRadioButtonGroup();
     resignStrongPasswordAppearance();
 
+    bool didSupportReadOnly = m_inputType->supportsReadOnly();
+    bool willSupportReadOnly = newType->supportsReadOnly();
+    std::optional<Style::PseudoClassChangeInvalidation> readWriteInvalidation;
+
     bool didStoreValue = m_inputType->storesValueSeparateFromAttribute();
     bool willStoreValue = newType->storesValueSeparateFromAttribute();
     bool neededSuspensionCallback = needsSuspensionCallback();
@@ -561,6 +561,11 @@ void HTMLInputElement::updateType()
 
     m_inputType = WTFMove(newType);
     m_inputType->createShadowSubtreeIfNeeded();
+
+    if (UNLIKELY(didSupportReadOnly != willSupportReadOnly && hasAttributeWithoutSynchronization(readonlyAttr))) {
+        emplace(readWriteInvalidation, *this, { { CSSSelector::PseudoClassReadWrite, !willSupportReadOnly }, { CSSSelector::PseudoClassReadOnly, willSupportReadOnly } });
+        readOnlyStateChanged();
+    }
 
     updateWillValidateAndValidity();
 
@@ -831,6 +836,11 @@ void HTMLInputElement::readOnlyStateChanged()
 {
     HTMLTextFormControlElement::readOnlyStateChanged();
     m_inputType->readOnlyStateChanged();
+}
+
+bool HTMLInputElement::supportsReadOnly() const
+{
+    return m_inputType->supportsReadOnly();
 }
 
 void HTMLInputElement::parserDidSetAttributes()
@@ -1276,7 +1286,7 @@ ExceptionOr<void> HTMLInputElement::showPicker()
     if (!frame)
         return { };
 
-    if (isDisabledOrReadOnly())
+    if (!isMutable())
         return Exception { InvalidStateError, "Input showPicker() cannot be used on immutable controls."_s };
 
     // In cross-origin iframes it should throw a "SecurityError" DOMException except on file and color. In same-origin iframes it should work fine.
@@ -1355,11 +1365,6 @@ Vector<String> HTMLInputElement::acceptMIMETypes() const
 Vector<String> HTMLInputElement::acceptFileExtensions() const
 {
     return parseAcceptAttribute(attributeWithoutSynchronization(acceptAttr), isValidFileExtension);
-}
-
-String HTMLInputElement::accept() const
-{
-    return attributeWithoutSynchronization(acceptAttr);
 }
 
 String HTMLInputElement::alt() const
@@ -1535,7 +1540,7 @@ bool HTMLInputElement::isRequiredFormControl() const
 
 bool HTMLInputElement::matchesReadWritePseudoClass() const
 {
-    return m_inputType->supportsReadOnly() && !isDisabledOrReadOnly();
+    return supportsReadOnly() && isMutable();
 }
 
 void HTMLInputElement::addSearchResult()
@@ -1736,7 +1741,8 @@ void HTMLInputElement::resetListAttributeTargetObserver()
 
 void HTMLInputElement::dataListMayHaveChanged()
 {
-    m_inputType->dataListMayHaveChanged();
+    auto protectedInputType = m_inputType;
+    protectedInputType->dataListMayHaveChanged();
 }
 
 bool HTMLInputElement::isFocusingWithDataListDropdown() const
@@ -1952,26 +1958,18 @@ bool HTMLInputElement::shouldAppearIndeterminate() const
 MediaCaptureType HTMLInputElement::mediaCaptureType() const
 {
     if (!isFileUpload())
-        return MediaCaptureTypeNone;
+        return MediaCaptureType::MediaCaptureTypeNone;
 
     auto& captureAttribute = attributeWithoutSynchronization(captureAttr);
     if (captureAttribute.isNull())
-        return MediaCaptureTypeNone;
+        return MediaCaptureType::MediaCaptureTypeNone;
 
     if (equalLettersIgnoringASCIICase(captureAttribute, "user"_s))
-        return MediaCaptureTypeUser;
+        return MediaCaptureType::MediaCaptureTypeUser;
 
-    return MediaCaptureTypeEnvironment;
+    return MediaCaptureType::MediaCaptureTypeEnvironment;
 }
 #endif
-
-bool HTMLInputElement::isInRequiredRadioButtonGroup()
-{
-    ASSERT(isRadioButton());
-    if (auto* buttons = radioButtonGroups())
-        return buttons->isInRequiredGroup(*this);
-    return false;
-}
 
 Vector<Ref<HTMLInputElement>> HTMLInputElement::radioButtonGroup() const
 {
@@ -2061,19 +2059,14 @@ ListAttributeTargetObserver::ListAttributeTargetObserver(const AtomString& id, H
 
 void ListAttributeTargetObserver::idTargetChanged()
 {
-    m_element->dataListMayHaveChanged();
+    m_element->document().eventLoop().queueTask(TaskSource::DOMManipulation, [element = m_element] {
+        if (element)
+            element->dataListMayHaveChanged();
+    });
 }
 #endif
 
-ExceptionOr<void> HTMLInputElement::setRangeText(const String& replacement)
-{
-    if (!m_inputType->supportsSelectionAPI())
-        return Exception { InvalidStateError };
-
-    return HTMLTextFormControlElement::setRangeText(replacement);
-}
-
-ExceptionOr<void> HTMLInputElement::setRangeText(const String& replacement, unsigned start, unsigned end, const String& selectionMode)
+ExceptionOr<void> HTMLInputElement::setRangeText(StringView replacement, unsigned start, unsigned end, const String& selectionMode)
 {
     if (!m_inputType->supportsSelectionAPI())
         return Exception { InvalidStateError };
@@ -2185,7 +2178,7 @@ RenderStyle HTMLInputElement::createInnerTextStyle(const RenderStyle& style)
 
     textBlockStyle.setDisplay(DisplayType::Block);
 
-    if (hasAutoFillStrongPasswordButton() && !isDisabledOrReadOnly()) {
+    if (hasAutoFillStrongPasswordButton() && isMutable()) {
         textBlockStyle.setDisplay(DisplayType::InlineBlock);
         textBlockStyle.setMaxWidth(Length { 100, LengthType::Percent });
         textBlockStyle.setColor(Color::black.colorWithAlphaByte(153));

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLInputElement.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLInputElement.h
@@ -24,12 +24,8 @@
 
 #pragma once
 
-#include "FileChooser.h"
 #include "HTMLTextFormControlElement.h"
-#include "SelectionRestorationMode.h"
 #include <memory>
-#include <wtf/WeakPtr.h>
-#include "ElementInlines.h"
 
 namespace WebCore {
 
@@ -45,6 +41,13 @@ class ListAttributeTargetObserver;
 class RadioButtonGroups;
 class StepRange;
 
+struct FileChooserFileInfo;
+
+enum class AnyStepHandling : bool;
+enum class DateComponentsType : uint8_t;
+enum class MediaCaptureType : uint8_t;
+enum class SelectionRestorationMode : uint8_t;
+
 struct InputElementClickState {
     bool stateful { false };
     bool checked { false };
@@ -52,8 +55,6 @@ struct InputElementClickState {
     RefPtr<HTMLInputElement> checkedRadioButton;
 };
 
-enum class AnyStepHandling : bool;
-enum class DateComponentsType : uint8_t;
 enum class WasSetByJavaScript : bool { No, Yes };
 
 class HTMLInputElement : public HTMLTextFormControlElement {
@@ -61,6 +62,50 @@ class HTMLInputElement : public HTMLTextFormControlElement {
 public:
     static Ref<HTMLInputElement> create(const QualifiedName&, Document&, HTMLFormElement*, bool createdByParser);
     virtual ~HTMLInputElement();
+
+    bool checked() const { return m_isChecked; }
+    WEBCORE_EXPORT void setChecked(bool);
+    WEBCORE_EXPORT FileList* files();
+    WEBCORE_EXPORT void setFiles(RefPtr<FileList>&&, WasSetByJavaScript = WasSetByJavaScript::No);
+    FileList* filesForBindings() { return files(); }
+    void setFilesForBindings(RefPtr<FileList>&& fileList) { return setFiles(WTFMove(fileList), WasSetByJavaScript::Yes); }
+    WEBCORE_EXPORT unsigned height() const;
+    WEBCORE_EXPORT void setHeight(unsigned);
+    bool indeterminate() const { return m_isIndeterminate; }
+    WEBCORE_EXPORT void setIndeterminate(bool);
+#if ENABLE(DATALIST_ELEMENT)
+    WEBCORE_EXPORT RefPtr<HTMLElement> list() const;
+#endif
+    unsigned size() const { return m_size; }
+    WEBCORE_EXPORT ExceptionOr<void> setSize(unsigned);
+    WEBCORE_EXPORT const AtomString& defaultValue() const;
+    WEBCORE_EXPORT void setDefaultValue(const AtomString&);
+    WEBCORE_EXPORT void setType(const AtomString&);
+    WEBCORE_EXPORT String value() const final;
+    WEBCORE_EXPORT ExceptionOr<void> setValue(const String&, TextFieldEventBehavior = DispatchNoEvent, TextControlSetValueSelection = TextControlSetValueSelection::SetSelectionToEnd) final;
+    void setValueForUser(const String& value) { setValue(value, DispatchInputAndChangeEvent); }
+    WEBCORE_EXPORT WallTime valueAsDate() const;
+    WEBCORE_EXPORT ExceptionOr<void> setValueAsDate(WallTime);
+    #if PLATFORM(JAVA)
+    WEBCORE_EXPORT ExceptionOr<void> setValueAsDate(double value);
+    #endif
+    WEBCORE_EXPORT double valueAsNumber() const;
+    WEBCORE_EXPORT ExceptionOr<void> setValueAsNumber(double, TextFieldEventBehavior = DispatchNoEvent);
+    WEBCORE_EXPORT ExceptionOr<void> stepUp(int = 1);
+    WEBCORE_EXPORT ExceptionOr<void> stepDown(int = 1);
+    WEBCORE_EXPORT unsigned width() const;
+    WEBCORE_EXPORT void setWidth(unsigned);
+    WEBCORE_EXPORT String validationMessage() const final;
+    std::optional<unsigned> selectionStartForBindings() const;
+    ExceptionOr<void> setSelectionStartForBindings(std::optional<unsigned>);
+    std::optional<unsigned> selectionEndForBindings() const;
+    ExceptionOr<void> setSelectionEndForBindings(std::optional<unsigned>);
+    ExceptionOr<String> selectionDirectionForBindings() const;
+    ExceptionOr<void> setSelectionDirectionForBindings(const String&);
+    using HTMLTextFormControlElement::setRangeText;
+    WEBCORE_EXPORT ExceptionOr<void> setRangeText(StringView, unsigned start, unsigned end, const String& selectionMode) final;
+    ExceptionOr<void> setSelectionRangeForBindings(unsigned start, unsigned end, const String& direction);
+    ExceptionOr<void> showPicker();
 
     WEBCORE_EXPORT bool shouldAutocomplete() const final;
 
@@ -75,7 +120,6 @@ public:
     bool typeMismatch() const final;
     bool valueMissing() const final;
     bool computeValidity() const final;
-    WEBCORE_EXPORT String validationMessage() const final;
 
     // Returns the minimum value for type=date, number, or range.  Don't call this for other types.
     double minimum() const;
@@ -91,9 +135,6 @@ public:
     std::optional<Decimal> findClosestTickMarkValue(const Decimal&);
     std::optional<double> listOptionValueAsDouble(const HTMLOptionElement&);
 #endif
-
-    WEBCORE_EXPORT ExceptionOr<void> stepUp(int = 1);
-    WEBCORE_EXPORT ExceptionOr<void> stepDown(int = 1);
 
     bool isPresentingAttachedView() const;
 
@@ -138,7 +179,6 @@ public:
 
     HTMLElement* innerBlockElement() const;
     HTMLElement* innerSpinButtonElement() const;
-    HTMLElement* capsLockIndicatorElement() const;
     HTMLElement* resultsButtonElement() const;
     HTMLElement* cancelButtonElement() const;
     HTMLElement* sliderThumbElement() const;
@@ -149,26 +189,14 @@ public:
     WEBCORE_EXPORT HTMLElement* dataListButtonElement() const;
 #endif
 
-    bool checked() const { return m_isChecked; }
-    WEBCORE_EXPORT void setChecked(bool);
-
-    // 'indeterminate' is a state independent of the checked state that causes the control to draw in a way that hides the actual state.
-    bool indeterminate() const { return m_isIndeterminate; }
-    WEBCORE_EXPORT void setIndeterminate(bool);
     // shouldAppearChecked is used by the rendering tree/CSS while checked() is used by JS to determine checked state
     bool shouldAppearChecked() const;
     bool matchesIndeterminatePseudoClass() const final;
     bool shouldAppearIndeterminate() const final;
 
-    unsigned size() const { return m_size; }
     bool sizeShouldIncludeDecoration(int& preferredSize) const;
     float decorationWidth() const;
 
-    WEBCORE_EXPORT void setType(const AtomString&);
-
-    WEBCORE_EXPORT String value() const final;
-    WEBCORE_EXPORT ExceptionOr<void> setValue(const String&, TextFieldEventBehavior = DispatchNoEvent, TextControlSetValueSelection = TextControlSetValueSelection::SetSelectionToEnd) final;
-    void setValueForUser(const String& value) { setValue(value, DispatchChangeEvent); }
     // Checks if the specified string would be a valid value.
     // We should not call this for types with no string value such as CHECKBOX and RADIO.
     bool isValidValue(const String&) const;
@@ -183,15 +211,6 @@ public:
     // The value which is drawn by a renderer.
     String visibleValue() const;
 
-    WEBCORE_EXPORT WallTime valueAsDate() const;
-    WEBCORE_EXPORT ExceptionOr<void> setValueAsDate(WallTime);
-    #if PLATFORM(JAVA)
-    WEBCORE_EXPORT ExceptionOr<void> setValueAsDate(double value);
-    #endif
-
-    WEBCORE_EXPORT double valueAsNumber() const;
-    WEBCORE_EXPORT ExceptionOr<void> setValueAsNumber(double, TextFieldEventBehavior = DispatchNoEvent);
-
     String valueWithDefault() const;
 
     // This function dispatches 'input' event for non-textfield types. Callers
@@ -199,17 +218,12 @@ public:
     // delay the 'input' event with EventQueueScope.
     void setValueFromRenderer(const String&);
 
-    bool canHaveSelection() const;
-
     bool rendererIsNeeded(const RenderStyle&) final;
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
     void willAttachRenderers() final;
     void didAttachRenderers() final;
     void didDetachRenderers() final;
 
-    // FIXME: For isActivatedSubmit and setActivatedSubmit, we should use the NVI-idiom here by making
-    // it private virtual in all classes and expose a public method in HTMLFormControlElement to call
-    // the private virtual method.
     bool isActivatedSubmit() const final;
     void setActivatedSubmit(bool flag) final;
 
@@ -222,15 +236,9 @@ public:
 
     int maxResults() const { return m_maxResults; }
 
-    WEBCORE_EXPORT const AtomString& defaultValue() const;
-    WEBCORE_EXPORT void setDefaultValue(const AtomString&);
-
     Vector<String> acceptMIMETypes() const;
     Vector<String> acceptFileExtensions() const;
-    String accept() const;
     WEBCORE_EXPORT String alt() const;
-
-    WEBCORE_EXPORT ExceptionOr<void> setSize(unsigned);
 
     URL src() const;
 
@@ -252,21 +260,15 @@ public:
     bool isAutoFillAvailable() const { return m_isAutoFillAvailable; }
     void setAutoFillAvailable(bool autoFillAvailable) { m_isAutoFillAvailable = autoFillAvailable; }
 
-    WEBCORE_EXPORT FileList* files();
-    WEBCORE_EXPORT void setFiles(RefPtr<FileList>&&, WasSetByJavaScript = WasSetByJavaScript::No);
-    FileList* filesForBindings() { return files(); }
-    void setFilesForBindings(RefPtr<FileList>&& fileList) { return setFiles(WTFMove(fileList), WasSetByJavaScript::Yes); }
-
 #if ENABLE(DRAG_SUPPORT)
-    // Returns true if the given DragData has more than one dropped files.
+    // Returns true if the given DragData has more than one dropped file.
     bool receiveDroppedFiles(const DragData&);
 #endif
 
     Icon* icon() const;
     String displayString() const;
 
-    // These functions are used for rendering the input active during a
-    // drag-and-drop operation.
+    // These functions are used for rendering the input active during a drag-and-drop operation.
     bool canReceiveDroppedFiles() const { return m_canReceiveDroppedFiles; }
     void setCanReceiveDroppedFiles(bool);
 
@@ -276,7 +278,6 @@ public:
     bool willRespondToMouseClickEventsWithEditability(Editability) const final;
 
 #if ENABLE(DATALIST_ELEMENT)
-    WEBCORE_EXPORT RefPtr<HTMLElement> list() const;
     WEBCORE_EXPORT bool isFocusingWithDataListDropdown() const;
     RefPtr<HTMLDataListElement> dataList() const;
     void dataListMayHaveChanged();
@@ -284,10 +285,8 @@ public:
 
     Vector<Ref<HTMLInputElement>> radioButtonGroup() const;
     RefPtr<HTMLInputElement> checkedRadioButtonForGroup() const;
-    bool isInRequiredRadioButtonGroup();
     // Returns null if this isn't associated with any radio button group.
     RadioButtonGroups* radioButtonGroups() const;
-
     // Functions for InputType classes.
     void setValueInternal(const String&, TextFieldEventBehavior);
     bool isTextFormControlFocusable() const;
@@ -313,11 +312,6 @@ public:
     // this, even when just clicking in the text field.
     static constexpr unsigned maxEffectiveLength = 524288;
 
-    WEBCORE_EXPORT unsigned height() const;
-    WEBCORE_EXPORT unsigned width() const;
-    WEBCORE_EXPORT void setHeight(unsigned);
-    WEBCORE_EXPORT void setWidth(unsigned);
-
     void blur() final;
     void defaultBlur();
 
@@ -331,8 +325,6 @@ public:
     static Vector<FileChooserFileInfo> filesFromFileInputFormControlState(const FormControlState&);
 
     bool matchesReadWritePseudoClass() const final;
-    WEBCORE_EXPORT ExceptionOr<void> setRangeText(const String& replacement) final;
-    WEBCORE_EXPORT ExceptionOr<void> setRangeText(const String& replacement, unsigned start, unsigned end, const String& selectionMode) final;
 
     HTMLImageLoader* imageLoader() { return m_imageLoader.get(); }
     HTMLImageLoader& ensureImageLoader();
@@ -340,26 +332,10 @@ public:
     void capsLockStateMayHaveChanged();
 
     bool shouldTruncateText(const RenderStyle&) const;
-    void invalidateStyleOnFocusChangeIfNeeded();
-
-    std::optional<unsigned> selectionStartForBindings() const;
-    ExceptionOr<void> setSelectionStartForBindings(std::optional<unsigned>);
-
-    std::optional<unsigned> selectionEndForBindings() const;
-    ExceptionOr<void> setSelectionEndForBindings(std::optional<unsigned>);
-
-    ExceptionOr<String> selectionDirectionForBindings() const;
-    ExceptionOr<void> setSelectionDirectionForBindings(const String&);
-
-    ExceptionOr<void> setSelectionRangeForBindings(unsigned start, unsigned end, const String& direction);
 
     String resultForDialogSubmit() const final;
 
     bool isInnerTextElementEditable() const final { return !hasAutoFillStrongPasswordButton() && HTMLTextFormControlElement::isInnerTextElementEditable(); }
-
-    void updateUserAgentShadowTree() final;
-
-    ExceptionOr<void> showPicker();
 
 protected:
     HTMLInputElement(const QualifiedName&, Document&, HTMLFormElement*, bool createdByParser);
@@ -367,7 +343,7 @@ protected:
     void defaultEventHandler(Event&) final;
 
 private:
-    enum AutoCompleteSetting { Uninitialized, On, Off };
+    enum AutoCompleteSetting : uint8_t { Uninitialized, On, Off };
     static constexpr int defaultSize = 20;
 
     void willChangeForm() final;
@@ -398,6 +374,7 @@ private:
 
     void resignStrongPasswordAppearance();
 
+    bool canHaveSelection() const;
     bool canStartSelection() const final;
 
     bool accessKeyAction(bool sendMouseEvents) final;
@@ -432,6 +409,7 @@ private:
     void registerForSuspensionCallbackIfNeeded();
     void unregisterForSuspensionCallbackIfNeeded();
 
+    bool supportsReadOnly() const final;
     bool supportsMinLength() const { return isTextType(); }
     bool supportsMaxLength() const { return isTextType(); }
     bool tooShort(StringView, NeedsToCheckDirtyFlag) const;
@@ -467,6 +445,9 @@ private:
     void removeFromRadioButtonGroup();
 
     void setDefaultSelectionAfterFocus(SelectionRestorationMode, SelectionRevealMode);
+    void invalidateStyleOnFocusChangeIfNeeded();
+
+    void updateUserAgentShadowTree() final;
 
     AtomString m_name;
     String m_valueIfDirty;

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLOptionElement.cpp
@@ -248,8 +248,11 @@ void HTMLOptionElement::setSelectedState(bool selected, AllowStyleInvalidation a
 void HTMLOptionElement::childrenChanged(const ChildChange& change)
 {
 #if ENABLE(DATALIST_ELEMENT)
+    Vector<Ref<HTMLDataListElement>> ancestors;
     for (auto& dataList : ancestorsOfType<HTMLDataListElement>(*this))
-        dataList.optionElementChildrenChanged();
+        ancestors.append(dataList);
+    for (auto& dataList : ancestors)
+        dataList->optionElementChildrenChanged();
 #endif
     if (RefPtr select = ownerSelectElement())
         select->optionElementChildrenChanged();

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
  *           (C) 2006 Alexey Proskuryakov (ap@nypop.com)
  * Copyright (C) 2007 Samuel Weinig (sam@webkit.org)
  *
@@ -56,12 +56,9 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(HTMLTextAreaElement);
 
 using namespace HTMLNames;
 
-static const int defaultRows = 2;
-static const int defaultCols = 20;
-
 // On submission, LF characters are converted into CRLF.
 // This function returns number of characters considering this.
-static inline unsigned computeLengthForSubmission(StringView text, unsigned numberOfLineBreaks)
+static unsigned computeLengthForSubmission(StringView text, unsigned numberOfLineBreaks)
 {
     return numGraphemeClusters(text) + numberOfLineBreaks;
 }
@@ -77,28 +74,26 @@ static unsigned numberOfLineBreaks(StringView text)
     return count;
 }
 
-static inline unsigned computeLengthForSubmission(StringView text)
+static unsigned computeLengthForSubmission(StringView text)
 {
     return numGraphemeClusters(text) + numberOfLineBreaks(text);
 }
 
-static inline unsigned upperBoundForLengthForSubmission(StringView text, unsigned numberOfLineBreaks)
+static unsigned upperBoundForLengthForSubmission(StringView text, unsigned numberOfLineBreaks)
 {
     return text.length() + numberOfLineBreaks;
 }
 
-HTMLTextAreaElement::HTMLTextAreaElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
-    : HTMLTextFormControlElement(tagName, document, form)
-    , m_rows(defaultRows)
-    , m_cols(defaultCols)
+HTMLTextAreaElement::HTMLTextAreaElement(Document& document, HTMLFormElement* form)
+    : HTMLTextFormControlElement(textareaTag, document, form)
 {
-    ASSERT(hasTagName(textareaTag));
     setFormControlValueMatchesRenderer(true);
 }
 
 Ref<HTMLTextAreaElement> HTMLTextAreaElement::create(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
 {
-    auto textArea = adoptRef(*new HTMLTextAreaElement(tagName, document, form));
+    ASSERT_UNUSED(tagName, tagName == textareaTag);
+    auto textArea = adoptRef(*new HTMLTextAreaElement(document, form));
     textArea->ensureUserAgentShadowRoot();
     return textArea;
 }
@@ -115,8 +110,7 @@ void HTMLTextAreaElement::didAddUserAgentShadowRoot(ShadowRoot& root)
 
 const AtomString& HTMLTextAreaElement::formControlType() const
 {
-    static MainThreadNeverDestroyed<const AtomString> textarea("textarea"_s);
-    return textarea;
+    return textareaTag->localName();
 }
 
 FormControlState HTMLTextAreaElement::saveFormControlState() const
@@ -146,7 +140,6 @@ bool HTMLTextAreaElement::hasPresentationalHintsForAttribute(const QualifiedName
         // See http://bugs.webkit.org/show_bug.cgi?id=7075
         return false;
     }
-
     if (name == wrapAttr)
         return true;
     return HTMLTextFormControlElement::hasPresentationalHintsForAttribute(name);
@@ -155,7 +148,7 @@ bool HTMLTextAreaElement::hasPresentationalHintsForAttribute(const QualifiedName
 void HTMLTextAreaElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
 {
     if (name == wrapAttr) {
-        if (shouldWrapText()) {
+        if (m_wrap != NoWrap) {
             addPropertyToPresentationalHintStyle(style, CSSPropertyWhiteSpace, CSSValuePreWrap);
             addPropertyToPresentationalHintStyle(style, CSSPropertyOverflowWrap, CSSValueBreakWord);
         } else {
@@ -197,24 +190,14 @@ void HTMLTextAreaElement::parseAttribute(const QualifiedName& name, const AtomSt
             if (renderer())
                 renderer()->setNeedsLayoutAndPrefWidthsRecalc();
         }
-    } else if (name == maxlengthAttr)
-        maxLengthAttributeChanged(value);
-    else if (name == minlengthAttr)
-        minLengthAttributeChanged(value);
-    else
+    } else if (name == maxlengthAttr) {
+        internalSetMaxLength(parseHTMLNonNegativeInteger(value).value_or(-1));
+    updateValidity();
+    } else if (name == minlengthAttr) {
+        internalSetMinLength(parseHTMLNonNegativeInteger(value).value_or(-1));
+    updateValidity();
+    } else
         HTMLTextFormControlElement::parseAttribute(name, value);
-}
-
-void HTMLTextAreaElement::maxLengthAttributeChanged(const AtomString& newValue)
-{
-    internalSetMaxLength(parseHTMLNonNegativeInteger(newValue).value_or(-1));
-    updateValidity();
-}
-
-void HTMLTextAreaElement::minLengthAttributeChanged(const AtomString& newValue)
-{
-    internalSetMinLength(parseHTMLNonNegativeInteger(newValue).value_or(-1));
-    updateValidity();
 }
 
 RenderPtr<RenderElement> HTMLTextAreaElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
@@ -227,42 +210,18 @@ bool HTMLTextAreaElement::appendFormData(DOMFormData& formData)
     if (name().isEmpty())
         return false;
 
-    Ref<HTMLTextAreaElement> protectedThis(*this);
+    Ref protectedThis(*this);
     document().updateLayout();
 
     formData.append(name(), m_wrap == HardWrap ? valueWithHardLineBreaks() : value());
-
-    auto& dirnameAttrValue = attributeWithoutSynchronization(dirnameAttr);
-    if (!dirnameAttrValue.isNull())
-        formData.append(dirnameAttrValue, directionForFormData());
-
+    if (auto& dirname = attributeWithoutSynchronization(dirnameAttr); !dirname.isNull())
+        formData.append(dirname, directionForFormData());
     return true;
 }
 
 void HTMLTextAreaElement::reset()
 {
     setNonDirtyValue(defaultValue(), TextControlSetValueSelection::SetSelectionToEnd);
-}
-
-bool HTMLTextAreaElement::hasCustomFocusLogic() const
-{
-    return true;
-}
-
-int HTMLTextAreaElement::defaultTabIndex() const
-{
-    return 0;
-}
-
-bool HTMLTextAreaElement::isKeyboardFocusable(KeyboardEvent*) const
-{
-    // If a given text area can be focused at all, then it will always be keyboard focusable.
-    return isFocusable();
-}
-
-bool HTMLTextAreaElement::isMouseFocusable() const
-{
-    return isFocusable();
 }
 
 void HTMLTextAreaElement::updateFocusAppearance(SelectionRestorationMode restorationMode, SelectionRevealMode revealMode)
@@ -306,7 +265,7 @@ void HTMLTextAreaElement::subtreeHasChanged()
 void HTMLTextAreaElement::handleBeforeTextInsertedEvent(BeforeTextInsertedEvent& event) const
 {
     ASSERT(renderer());
-    int signedMaxLength = effectiveMaxLength();
+    int signedMaxLength = maxLength();
     if (signedMaxLength < 0)
         return;
     unsigned unsignedMaxLength = static_cast<unsigned>(signedMaxLength);
@@ -328,31 +287,21 @@ void HTMLTextAreaElement::handleBeforeTextInsertedEvent(BeforeTextInsertedEvent&
     ASSERT(currentLength >= selectionLength);
     unsigned baseLength = currentLength - selectionLength;
     unsigned appendableLength = unsignedMaxLength > baseLength ? unsignedMaxLength - baseLength : 0;
-    event.setText(sanitizeUserInputValue(event.text(), appendableLength));
-}
-
-String HTMLTextAreaElement::sanitizeUserInputValue(const String& proposedValue, unsigned maxLength)
-{
-    return proposedValue.left(numCodeUnitsInGraphemeClusters(proposedValue, maxLength));
+    auto text = event.text();
+    event.setText(text.left(numCodeUnitsInGraphemeClusters(text, appendableLength)));
 }
 
 RefPtr<TextControlInnerTextElement> HTMLTextAreaElement::innerTextElement() const
 {
-    RefPtr<ShadowRoot> root = userAgentShadowRoot();
+    RefPtr root = userAgentShadowRoot();
     if (!root)
         return nullptr;
-
     return childrenOfType<TextControlInnerTextElement>(*root).first();
 }
 
 RefPtr<TextControlInnerTextElement> HTMLTextAreaElement::innerTextElementCreatingShadowSubtreeIfNeeded()
 {
     return innerTextElement();
-}
-
-void HTMLTextAreaElement::rendererWillBeDestroyed()
-{
-    updateValue();
 }
 
 void HTMLTextAreaElement::updateValue() const
@@ -450,19 +399,38 @@ String HTMLTextAreaElement::validationMessage() const
         return validationMessageTooShortText(computeLengthForSubmission(value()), minLength());
 
     if (tooLong())
-        return validationMessageTooLongText(computeLengthForSubmission(value()), effectiveMaxLength());
+        return validationMessageTooLongText(computeLengthForSubmission(value()), maxLength());
 
     return String();
 }
 
 bool HTMLTextAreaElement::valueMissing() const
 {
-    return willValidate() && valueMissing(value());
+    return willValidate() && valueMissing({ });
 }
 
 bool HTMLTextAreaElement::tooShort() const
 {
-    return willValidate() && tooShort(value(), CheckDirtyFlag);
+    return willValidate() && tooShort({ }, CheckDirtyFlag);
+}
+
+bool HTMLTextAreaElement::tooLong() const
+{
+    return willValidate() && tooLong({ }, CheckDirtyFlag);
+}
+
+bool HTMLTextAreaElement::valueMissing(StringView value) const
+{
+    if (!(isRequired() && isMutable()))
+        return false;
+    if (value.isNull())
+        value = this->value();
+    return value.isEmpty();
+}
+
+bool HTMLTextAreaElement::isValidValue(StringView candidate) const
+{
+    return !valueMissing(candidate) && !tooShort(candidate, IgnoreDirtyFlag) && !tooLong(candidate, IgnoreDirtyFlag);
 }
 
 bool HTMLTextAreaElement::tooShort(StringView value, NeedsToCheckDirtyFlag check) const
@@ -476,6 +444,9 @@ bool HTMLTextAreaElement::tooShort(StringView value, NeedsToCheckDirtyFlag check
     if (min <= 0)
         return false;
 
+    if (value.isNull())
+        value = this->value();
+
     // The empty string is excluded from tooShort validation.
     if (value.isEmpty())
         return false;
@@ -488,11 +459,6 @@ bool HTMLTextAreaElement::tooShort(StringView value, NeedsToCheckDirtyFlag check
         && computeLengthForSubmission(value, numberOfLineBreaksInValue) < unsignedMin;
 }
 
-bool HTMLTextAreaElement::tooLong() const
-{
-    return willValidate() && tooLong(value(), CheckDirtyFlag);
-}
-
 bool HTMLTextAreaElement::tooLong(StringView value, NeedsToCheckDirtyFlag check) const
 {
     // Return false for the default value or value set by script even if it is
@@ -500,21 +466,19 @@ bool HTMLTextAreaElement::tooLong(StringView value, NeedsToCheckDirtyFlag check)
     if (check == CheckDirtyFlag && !m_wasModifiedByUser)
         return false;
 
-    int max = effectiveMaxLength();
+    int max = maxLength();
     if (max < 0)
         return false;
 
+    if (value.isNull())
+        value = this->value();
+
     // FIXME: The HTML specification says that the "number of characters" is measured using code-unit length and,
     // in the case of textarea elements, with all line breaks normalized to a single character (as opposed to CRLF pairs).
-    unsigned unsignedMax = static_cast<unsigned>(max);
+    unsigned unsignedMax = max;
     unsigned numberOfLineBreaksInValue = numberOfLineBreaks(value);
     return upperBoundForLengthForSubmission(value, numberOfLineBreaksInValue) > unsignedMax
         && computeLengthForSubmission(value, numberOfLineBreaksInValue) > unsignedMax;
-}
-
-bool HTMLTextAreaElement::isValidValue(const String& candidate) const
-{
-    return !valueMissing(candidate) && !tooShort(candidate, IgnoreDirtyFlag) && !tooLong(candidate, IgnoreDirtyFlag);
 }
 
 bool HTMLTextAreaElement::accessKeyAction(bool)
@@ -533,21 +497,6 @@ void HTMLTextAreaElement::setRows(unsigned rows)
     setUnsignedIntegralAttribute(rowsAttr, limitToOnlyHTMLNonNegativeNumbersGreaterThanZero(rows, defaultRows));
 }
 
-bool HTMLTextAreaElement::shouldUseInputMethod()
-{
-    return true;
-}
-
-HTMLElement* HTMLTextAreaElement::placeholderElement() const
-{
-    return m_placeholder.get();
-}
-
-bool HTMLTextAreaElement::matchesReadWritePseudoClass() const
-{
-    return !isDisabledOrReadOnly();
-}
-
 void HTMLTextAreaElement::updatePlaceholderText()
 {
     auto& placeholderText = attributeWithoutSynchronization(placeholderAttr);
@@ -563,11 +512,6 @@ void HTMLTextAreaElement::updatePlaceholderText()
         userAgentShadowRoot()->insertBefore(*m_placeholder, innerTextElement()->nextSibling());
     }
     m_placeholder->setInnerText(String { placeholderText });
-}
-
-bool HTMLTextAreaElement::willRespondToMouseClickEventsWithEditability(Editability) const
-{
-    return !isDisabledFormControl();
 }
 
 RenderStyle HTMLTextAreaElement::createInnerTextStyle(const RenderStyle& style)

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLTextAreaElement.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLTextAreaElement.h
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004, 2005, 2006, 2007, 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -24,13 +24,13 @@
 #pragma once
 
 #include "HTMLTextFormControlElement.h"
-#include "SelectionRestorationMode.h"
 
 namespace WebCore {
 
 class BeforeTextInsertedEvent;
 class RenderTextControlMultiLine;
-class VisibleSelection;
+
+enum class SelectionRestorationMode : uint8_t;
 
 class HTMLTextAreaElement final : public HTMLTextFormControlElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLTextAreaElement);
@@ -38,56 +38,35 @@ public:
     WEBCORE_EXPORT static Ref<HTMLTextAreaElement> create(Document&);
     static Ref<HTMLTextAreaElement> create(const QualifiedName&, Document&, HTMLFormElement*);
 
-    unsigned cols() const { return m_cols; }
     unsigned rows() const { return m_rows; }
-
-    bool shouldWrapText() const { return m_wrap != NoWrap; }
-
-    WEBCORE_EXPORT String value() const final;
-    WEBCORE_EXPORT ExceptionOr<void> setValue(const String&, TextFieldEventBehavior = DispatchNoEvent, TextControlSetValueSelection = TextControlSetValueSelection::SetSelectionToEnd) final;
+    WEBCORE_EXPORT void setRows(unsigned);
+    unsigned cols() const { return m_cols; }
+    WEBCORE_EXPORT void setCols(unsigned);
     WEBCORE_EXPORT String defaultValue() const;
     WEBCORE_EXPORT void setDefaultValue(String&&);
-    int textLength() const { return value().length(); }
-    int effectiveMaxLength() const { return maxLength(); }
-    // For ValidityState
+    WEBCORE_EXPORT String value() const final;
+    WEBCORE_EXPORT ExceptionOr<void> setValue(const String&, TextFieldEventBehavior = DispatchNoEvent, TextControlSetValueSelection = TextControlSetValueSelection::SetSelectionToEnd) final;
+    unsigned textLength() const { return value().length(); }
     String validationMessage() const final;
-    bool valueMissing() const final;
-    bool tooShort() const final;
-    bool tooLong() const final;
-    bool isValidValue(const String&) const;
+
+    void rendererWillBeDestroyed() { updateValue(); }
 
     WEBCORE_EXPORT RefPtr<TextControlInnerTextElement> innerTextElement() const final;
-    WEBCORE_EXPORT RefPtr<TextControlInnerTextElement> innerTextElementCreatingShadowSubtreeIfNeeded() final;
-    RenderStyle createInnerTextStyle(const RenderStyle&) final;
-    void copyNonAttributePropertiesFromElement(const Element&) final;
-
-    void rendererWillBeDestroyed();
-
-    WEBCORE_EXPORT void setCols(unsigned);
-    WEBCORE_EXPORT void setRows(unsigned);
-
-    bool willRespondToMouseClickEventsWithEditability(Editability) const final;
-
-    RenderTextControlMultiLine* renderer() const;
 
 private:
-    HTMLTextAreaElement(const QualifiedName&, Document&, HTMLFormElement*);
-
-    enum WrapMethod { NoWrap, SoftWrap, HardWrap };
+    HTMLTextAreaElement(Document&, HTMLFormElement*);
 
     void didAddUserAgentShadowRoot(ShadowRoot&) final;
 
-    void maxLengthAttributeChanged(const AtomString& newValue);
-    void minLengthAttributeChanged(const AtomString& newValue);
-
     void handleBeforeTextInsertedEvent(BeforeTextInsertedEvent&) const;
-    static String sanitizeUserInputValue(const String&, unsigned maxLength);
     void updateValue() const;
     void setNonDirtyValue(const String&, TextControlSetValueSelection);
     void setValueCommon(const String&, TextFieldEventBehavior, TextControlSetValueSelection);
 
+    bool supportsReadOnly() const final { return true; }
+
     bool supportsPlaceholder() const final { return true; }
-    HTMLElement* placeholderElement() const final;
+    HTMLElement* placeholderElement() const final { return m_placeholder.get(); }
     void updatePlaceholderText() final;
     bool isEmptyValue() const final { return value().isEmpty(); }
 
@@ -117,28 +96,46 @@ private:
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
     bool appendFormData(DOMFormData&) final;
     void reset() final;
-    bool hasCustomFocusLogic() const final;
-    int defaultTabIndex() const final;
-    bool isMouseFocusable() const final;
-    bool isKeyboardFocusable(KeyboardEvent*) const final;
+    bool hasCustomFocusLogic() const final { return true; }
+    int defaultTabIndex() const final { return 0; }
+    bool isMouseFocusable() const final { return isFocusable(); }
+    bool isKeyboardFocusable(KeyboardEvent*) const final { return isFocusable(); }
     void updateFocusAppearance(SelectionRestorationMode, SelectionRevealMode) final;
 
-    bool accessKeyAction(bool sendMouseEvents) final;
+    bool accessKeyAction(bool) final;
 
-    bool shouldUseInputMethod() final;
-    bool matchesReadWritePseudoClass() const final;
+    bool shouldUseInputMethod() final { return true; }
+    bool matchesReadWritePseudoClass() const final { return isMutable(); }
 
-    bool valueMissing(const String& value) const { return isRequiredFormControl() && !isDisabledOrReadOnly() && value.isEmpty(); }
-    bool tooShort(StringView, NeedsToCheckDirtyFlag) const;
-    bool tooLong(StringView, NeedsToCheckDirtyFlag) const;
+    bool valueMissing() const final;
+    bool tooShort() const final;
+    bool tooLong() const final;
+    bool isValidValue(StringView) const;
 
-    unsigned m_rows;
-    unsigned m_cols;
-    WrapMethod m_wrap { SoftWrap };
+    bool valueMissing(StringView valueOverride) const;
+    bool tooShort(StringView valueOverride, NeedsToCheckDirtyFlag) const;
+    bool tooLong(StringView valueOverride, NeedsToCheckDirtyFlag) const;
+
+    RefPtr<TextControlInnerTextElement> innerTextElementCreatingShadowSubtreeIfNeeded() final;
+    RenderStyle createInnerTextStyle(const RenderStyle&) final;
+    void copyNonAttributePropertiesFromElement(const Element&) final;
+
+    bool willRespondToMouseClickEventsWithEditability(Editability) const final { return !isDisabledFormControl(); }
+
+    RenderTextControlMultiLine* renderer() const;
+
+    enum WrapMethod : uint8_t { NoWrap, SoftWrap, HardWrap };
+
+    static constexpr unsigned defaultRows = 2;
+    static constexpr unsigned defaultCols = 20;
+
+    unsigned m_rows { defaultRows };
+    unsigned m_cols { defaultCols };
     RefPtr<HTMLElement> m_placeholder;
     mutable String m_value;
-    mutable bool m_isDirty { false };
-    mutable bool m_wasModifiedByUser { false };
+    WrapMethod m_wrap { SoftWrap };
+    mutable uint8_t m_isDirty { false }; // uint8_t for better packing on Windows
+    mutable uint8_t m_wasModifiedByUser { false }; // uint8_t for better packing on Windows
 };
 
-} //namespace
+} // namespace

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -238,12 +238,12 @@ void HTMLTextFormControlElement::dispatchFormControlChangeEvent()
     setChangedSinceLastFormControlChangeEvent(false);
 }
 
-ExceptionOr<void> HTMLTextFormControlElement::setRangeText(const String& replacement)
+ExceptionOr<void> HTMLTextFormControlElement::setRangeText(StringView replacement)
 {
     return setRangeText(replacement, selectionStart(), selectionEnd(), String());
 }
 
-ExceptionOr<void> HTMLTextFormControlElement::setRangeText(const String& replacement, unsigned start, unsigned end, const String& selectionMode)
+ExceptionOr<void> HTMLTextFormControlElement::setRangeText(StringView replacement, unsigned start, unsigned end, const String& selectionMode)
 {
     if (start > end)
         return Exception { IndexSizeError };
@@ -573,7 +573,7 @@ void HTMLTextFormControlElement::readOnlyStateChanged()
 
 bool HTMLTextFormControlElement::isInnerTextElementEditable() const
 {
-    return !isDisabledOrReadOnly();
+    return isMutable();
 }
 
 void HTMLTextFormControlElement::updateInnerTextElementEditability()

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLTextFormControlElement.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLTextFormControlElement.h
@@ -77,8 +77,8 @@ public:
     WEBCORE_EXPORT void setSelectionEnd(unsigned);
     WEBCORE_EXPORT void setSelectionDirection(const String&);
     WEBCORE_EXPORT void select(SelectionRevealMode = SelectionRevealMode::DoNotReveal, const AXTextStateChangeIntent& = AXTextStateChangeIntent());
-    WEBCORE_EXPORT virtual ExceptionOr<void> setRangeText(const String& replacement);
-    WEBCORE_EXPORT virtual ExceptionOr<void> setRangeText(const String& replacement, unsigned start, unsigned end, const String& selectionMode);
+    WEBCORE_EXPORT ExceptionOr<void> setRangeText(StringView replacement);
+    WEBCORE_EXPORT virtual ExceptionOr<void> setRangeText(StringView replacement, unsigned start, unsigned end, const String& selectionMode);
     void setSelectionRange(unsigned start, unsigned end, const String& direction, const AXTextStateChangeIntent& = AXTextStateChangeIntent());
     WEBCORE_EXPORT bool setSelectionRange(unsigned start, unsigned end, TextFieldSelectionDirection = SelectionHasNoDirection, SelectionRevealMode = SelectionRevealMode::DoNotReveal, const AXTextStateChangeIntent& = AXTextStateChangeIntent());
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLVideoElement.cpp
@@ -367,9 +367,6 @@ bool HTMLVideoElement::webkitSupportsFullscreen()
 
 bool HTMLVideoElement::webkitDisplayingFullscreen()
 {
-    if (document().quirks().needsAkamaiMediaPlayerQuirk(*this))
-        return isFullscreen() || isChangingVideoFullscreenMode();
-
     return isFullscreen();
 }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/InputType.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/InputType.h
@@ -320,7 +320,6 @@ public:
     virtual HTMLElement* innerBlockElement() const { return nullptr; }
     virtual RefPtr<TextControlInnerTextElement> innerTextElement() const;
     virtual HTMLElement* innerSpinButtonElement() const { return nullptr; }
-    virtual HTMLElement* capsLockIndicatorElement() const { return nullptr; }
     virtual HTMLElement* autoFillButtonElement() const { return nullptr; }
     virtual HTMLElement* resultsButtonElement() const { return nullptr; }
     virtual HTMLElement* cancelButtonElement() const { return nullptr; }

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/MediaElementSession.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/MediaElementSession.cpp
@@ -420,9 +420,6 @@ Expected<void, MediaPlaybackDenialReason> MediaElementSession::playbackStateChan
     if (topDocument.mediaState() & MediaProducerMediaState::HasUserInteractedWithMediaElement && topDocument.quirks().needsPerDocumentAutoplayBehavior())
         return { };
 
-    if (topDocument.hasHadUserInteraction() && document.quirks().shouldAutoplayForArbitraryUserGesture())
-        return { };
-
     if (m_restrictions & RequireUserGestureForVideoRateChange && m_element.isVideo() && !document.processingUserGestureForMedia()) {
         ALWAYS_LOG(LOGIDENTIFIER, "Returning FALSE because a user gesture is required for video rate change restriction");
         return makeUnexpected(MediaPlaybackDenialReason::UserGestureRequired);
@@ -1222,7 +1219,7 @@ std::optional<NowPlayingInfo> MediaElementSession::nowPlayingInfo() const
         std::optional<NowPlayingInfoArtwork> artwork;
         if (sessionMetadata->artworkImage()) {
             ASSERT(sessionMetadata->artworkImage()->data(), "An image must always have associated data");
-            artwork = NowPlayingInfoArtwork { sessionMetadata->artworkSrc(), sessionMetadata->artworkImage()->mimeType(), sessionMetadata->artworkImage()->data() };
+            artwork = NowPlayingInfoArtwork { sessionMetadata->artworkSrc(), sessionMetadata->artworkImage()->mimeType(), sessionMetadata->artworkImage() };
         }
         return NowPlayingInfo { sessionMetadata->title(), sessionMetadata->artist(), sessionMetadata->album(), sourceApplicationIdentifier, duration, currentTime, rate, supportsSeeking, m_element.mediaUniqueIdentifier(), isPlaying, allowsNowPlayingControlsVisibility, WTFMove(artwork) };
     }
@@ -1277,7 +1274,6 @@ void MediaElementSession::updateMediaUsageIfChanged()
         document.isMediaDocument() && !document.ownerElement(),
         pageExplicitlyAllowsElementToAutoplayInline(m_element),
         requiresFullscreenForVideoPlayback() && !fullscreenPermitted(),
-        document.topDocument().hasHadUserInteraction() && document.quirks().shouldAutoplayForArbitraryUserGesture(),
         isVideo && hasBehaviorRestriction(RequireUserGestureForVideoRateChange) && !processingUserGesture,
         isAudio && hasBehaviorRestriction(RequireUserGestureForAudioRateChange) && !processingUserGesture && !m_element.muted() && m_element.volume(),
         isVideo && hasBehaviorRestriction(RequireUserGestureForVideoDueToLowPowerMode) && !processingUserGesture,

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/SearchInputType.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/SearchInputType.cpp
@@ -139,13 +139,13 @@ HTMLElement* SearchInputType::cancelButtonElement() const
 auto SearchInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallBaseEventHandler
 {
     ASSERT(element());
-    if (element()->isDisabledOrReadOnly())
+    if (!element()->isMutable())
         return TextFieldInputType::handleKeydownEvent(event);
 
     const String& key = event.keyIdentifier();
     if (key == "U+001B"_s) {
         Ref<HTMLInputElement> protectedInputElement(*element());
-        protectedInputElement->setValueForUser(emptyString());
+        protectedInputElement->setValue(emptyString(), DispatchChangeEvent);
         protectedInputElement->onSearch();
         event.setDefaultHandled();
         return ShouldCallBaseEventHandler::Yes;

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/TextFieldInputType.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/TextFieldInputType.cpp
@@ -125,7 +125,7 @@ bool TextFieldInputType::isEmptyValue() const
 bool TextFieldInputType::valueMissing(const String& value) const
 {
     ASSERT(element());
-    return !element()->isDisabledOrReadOnly() && element()->isRequired() && value.isEmpty();
+    return element()->isMutable() && element()->isRequired() && value.isEmpty();
 }
 
 void TextFieldInputType::setValue(const String& sanitizedValue, bool valueChanged, TextFieldEventBehavior eventBehavior, TextControlSetValueSelection selection)
@@ -213,7 +213,7 @@ auto TextFieldInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallB
 void TextFieldInputType::handleKeydownEventForSpinButton(KeyboardEvent& event)
 {
     ASSERT(element());
-    if (element()->isDisabledOrReadOnly())
+    if (!element()->isMutable())
         return;
 #if ENABLE(DATALIST_ELEMENT)
     if (m_suggestionPicker)
@@ -407,11 +407,6 @@ HTMLElement* TextFieldInputType::innerSpinButtonElement() const
     return m_innerSpinButton.get();
 }
 
-HTMLElement* TextFieldInputType::capsLockIndicatorElement() const
-{
-    return m_capsLockIndicator.get();
-}
-
 HTMLElement* TextFieldInputType::autoFillButtonElement() const
 {
     return m_autoFillButton.get();
@@ -487,6 +482,8 @@ void TextFieldInputType::createDataListDropdownIndicator()
     ASSERT(!m_dataListDropdownIndicator);
     if (!m_container)
         createContainer();
+    if (!element())
+        return;
 
     ScriptDisallowedScope::EventAllowedScope allowedScope(*m_container);
     m_dataListDropdownIndicator = DataListButtonElement::create(element()->document(), *this);
@@ -766,7 +763,7 @@ void TextFieldInputType::focusAndSelectSpinButtonOwner()
 bool TextFieldInputType::shouldSpinButtonRespondToMouseEvents() const
 {
     ASSERT(element());
-    return !element()->isDisabledOrReadOnly();
+    return element()->isMutable();
 }
 
 bool TextFieldInputType::shouldSpinButtonRespondToWheelEvents() const
@@ -781,7 +778,7 @@ bool TextFieldInputType::shouldDrawCapsLockIndicator() const
     if (element()->document().focusedElement() != element())
         return false;
 
-    if (element()->isDisabledOrReadOnly())
+    if (!element()->isMutable())
         return false;
 
     if (element()->hasAutoFillStrongPasswordButton())
@@ -809,7 +806,7 @@ void TextFieldInputType::capsLockStateMayHaveChanged()
 bool TextFieldInputType::shouldDrawAutoFillButton() const
 {
     ASSERT(element());
-    return !element()->isDisabledOrReadOnly() && element()->autoFillButtonType() != AutoFillButtonType::None;
+    return element()->isMutable() && element()->autoFillButtonType() != AutoFillButtonType::None;
 }
 
 void TextFieldInputType::autoFillButtonElementWasClicked()
@@ -900,7 +897,8 @@ void TextFieldInputType::dataListMayHaveChanged()
 
     if (!m_dataListDropdownIndicator)
         createDataListDropdownIndicator();
-
+    if (!element())
+        return;
     if (!shouldOnlyShowDataListDropdownButtonWhenFocusedOrEdited())
         m_dataListDropdownIndicator->setInlineStyleProperty(CSSPropertyDisplay, element()->list() ? CSSValueBlock : CSSValueNone, true);
 }

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/TextFieldInputType.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/TextFieldInputType.h
@@ -66,7 +66,6 @@ protected:
     HTMLElement* innerBlockElement() const final;
     RefPtr<TextControlInnerTextElement> innerTextElement() const final;
     HTMLElement* innerSpinButtonElement() const final;
-    HTMLElement* capsLockIndicatorElement() const final;
     HTMLElement* autoFillButtonElement() const final;
 #if ENABLE(DATALIST_ELEMENT)
     HTMLElement* dataListButtonElement() const final;

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -214,7 +214,7 @@ private:
                 m_sizesAttribute = WTFMove(attributeValue);
                 break;
             }
-            if (m_document.settings().lazyImageLoadingEnabled()) {
+            if (m_document.lazyImageLoadingEnabled()) {
                 if (match(attributeName, loadingAttr) && m_lazyloadAttribute.isNull()) {
                     m_lazyloadAttribute = WTFMove(attributeValue);
                     break;

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -471,7 +471,7 @@ void SliderThumbElement::handleTouchEvent(TouchEvent& touchEvent)
 {
     auto input = hostInput();
     ASSERT(input);
-    if (input->isReadOnly() || input->isDisabledFormControl()) {
+    if (!input->isMutable()) {
         clearExclusiveTouchIdentifier();
         stopDragging();
         touchEvent.setDefaultHandled();

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -321,7 +321,7 @@ std::optional<Style::ElementStyle> SearchFieldCancelButtonElement::resolveCustom
 void SearchFieldCancelButtonElement::defaultEventHandler(Event& event)
 {
     RefPtr<HTMLInputElement> input(downcast<HTMLInputElement>(shadowHost()));
-    if (!input || input->isDisabledOrReadOnly()) {
+    if (!input || !input->isMutable()) {
         if (!event.defaultHandled())
             HTMLDivElement::defaultEventHandler(event);
         return;
@@ -334,7 +334,7 @@ void SearchFieldCancelButtonElement::defaultEventHandler(Event& event)
     }
 
     if (event.type() == eventNames().clickEvent) {
-        input->setValueForUser(emptyString());
+        input->setValue(emptyString(), DispatchChangeEvent);
         input->onSearch();
         event.setDefaultHandled();
     }
@@ -347,7 +347,7 @@ void SearchFieldCancelButtonElement::defaultEventHandler(Event& event)
 bool SearchFieldCancelButtonElement::willRespondToMouseClickEventsWithEditability(Editability editability) const
 {
     const RefPtr<HTMLInputElement> input = downcast<HTMLInputElement>(shadowHost());
-    if (input && !input->isDisabledOrReadOnly())
+    if (input && input->isMutable())
         return true;
 
     return HTMLDivElement::willRespondToMouseClickEventsWithEditability(editability);

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/track/VTTCue.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/track/VTTCue.cpp
@@ -1338,9 +1338,9 @@ void VTTCue::toJSON(JSON::Object& object) const
     object.setString("vertical"_s, vertical());
     object.setBoolean("snapToLines"_s, snapToLines());
     if (m_linePosition)
-        object.setString("line"_s, autoAtom());
-    else
         object.setDouble("line"_s, *m_linePosition);
+    else
+        object.setString("line"_s, autoAtom());
     if (m_textPosition)
         object.setDouble("position"_s, *m_textPosition);
     else

--- a/modules/javafx.web/src/main/native/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -704,16 +704,16 @@ std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvas::pro
     return {{ JSON::Value::create(0), RecordingSwizzleType::WebGLUniformLocation }};
 }
 
+#endif // ENABLE(WEBGL)
+
+#if ENABLE(WEBGL2)
+
 std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvas::processArgument(WebGLVertexArrayObject* argument)
 {
     if (!argument)
         return std::nullopt;
     return {{ JSON::Value::create(0), RecordingSwizzleType::WebGLVertexArrayObject }};
 }
-
-#endif // ENABLE(WEBGL)
-
-#if ENABLE(WEBGL2)
 
 std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvas::processArgument(WebGLTransformFeedback* argument)
 {

--- a/modules/javafx.web/src/main/native/Source/WebCore/inspector/InspectorCanvasCallTracer.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/inspector/InspectorCanvasCallTracer.h
@@ -122,7 +122,6 @@ enum ImageSmoothingQuality;
     macro(WebGLSync*) \
     macro(WebGLTexture*) \
     macro(WebGLUniformLocation*) \
-    macro(WebGLVertexArrayObject*) \
 // end of FOR_EACH_INSPECTOR_CANVAS_CALL_TRACER_WEBGL_ARGUMENT
 #else
 #define FOR_EACH_INSPECTOR_CANVAS_CALL_TRACER_WEBGL_ARGUMENT(macro)
@@ -132,6 +131,7 @@ enum ImageSmoothingQuality;
 #define FOR_EACH_INSPECTOR_CANVAS_CALL_TRACER_WEBGL2_ARGUMENT(macro) \
     macro(WebGLTransformFeedback*) \
     macro(WebGL2RenderingContext::Uint32List::VariantType&) \
+    macro(WebGLVertexArrayObject*) \
 // end of FOR_EACH_INSPECTOR_CANVAS_CALL_TRACER_WEBGL2_ARGUMENT
 #else
 #define FOR_EACH_INSPECTOR_CANVAS_CALL_TRACER_WEBGL2_ARGUMENT(macro)

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/DocumentLoader.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/DocumentLoader.cpp
@@ -1202,17 +1202,20 @@ void DocumentLoader::commitLoad(const SharedBuffer& data)
 
 ResourceError DocumentLoader::interruptedForPolicyChangeError() const
 {
-    if (!frameLoader())
-        return {};
+    if (!frameLoader()) {
+        ResourceError error;
+        error.setType(ResourceError::Type::Cancellation);
+        return error;
+    }
 
-    return frameLoader()->client().interruptedForPolicyChangeError(request());
+    auto error = frameLoader()->client().interruptedForPolicyChangeError(request());
+    error.setType(ResourceError::Type::Cancellation);
+    return error;
 }
 
 void DocumentLoader::stopLoadingForPolicyChange()
 {
-    ResourceError error = interruptedForPolicyChangeError();
-    error.setType(ResourceError::Type::Cancellation);
-    cancelMainResourceLoad(error);
+    cancelMainResourceLoad(interruptedForPolicyChangeError());
 }
 
 #if ENABLE(SERVICE_WORKER)

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/EmptyClients.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/EmptyClients.cpp
@@ -51,7 +51,6 @@
 #include "EditorClient.h"
 #include "EmptyAttachmentElementClient.h"
 #include "EmptyFrameLoaderClient.h"
-#include "FileChooser.h"
 #include "FormState.h"
 #include "Frame.h"
 #include "FrameLoaderClient.h"
@@ -212,7 +211,7 @@ class EmptyDatabaseProvider final : public DatabaseProvider {
         void establishTransaction(uint64_t, const IDBTransactionInfo&) final { }
         void databaseConnectionPendingClose(uint64_t) final { }
         void databaseConnectionClosed(uint64_t) final { }
-        void abortOpenAndUpgradeNeeded(uint64_t, const IDBResourceIdentifier&) final { }
+        void abortOpenAndUpgradeNeeded(uint64_t, const std::optional<IDBResourceIdentifier>&) final { }
         void didFireVersionChangeEvent(uint64_t, const IDBResourceIdentifier&, const IndexedDB::ConnectionClosedOnBehalfOfServer) final { }
         void openDBRequestCancelled(const IDBRequestData&) final { }
         void getAllDatabaseNamesAndVersions(const IDBResourceIdentifier&, const ClientOrigin&) final { }

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/FormSubmission.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/FormSubmission.cpp
@@ -241,13 +241,11 @@ Ref<FormSubmission> FormSubmission::create(HTMLFormElement& form, HTMLFormContro
 
 URL FormSubmission::requestURL() const
 {
-    ASSERT(m_method == Method::Post || m_method == Method::Get);
-
     if (m_method == Method::Post)
         return m_action;
 
     URL requestURL(m_action);
-    if (!requestURL.protocolIsJavaScript())
+    if (m_method == Method::Get && !requestURL.protocolIsJavaScript())
         requestURL.setQuery(m_formData->flattenToString());
     return requestURL;
 }

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/FrameLoader.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/FrameLoader.h
@@ -469,9 +469,6 @@ private:
 
     PageDismissalType m_pageDismissalEventBeingDispatched { PageDismissalType::None };
     bool m_isComplete;
-
-    RefPtr<SerializedScriptValue> m_pendingStateObject;
-
     bool m_needsClear;
 
     URL m_submittedFormURL;

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/HistoryController.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/HistoryController.cpp
@@ -860,12 +860,12 @@ void FrameLoader::HistoryController::pushState(RefPtr<SerializedScriptValue>&& s
 
     bool shouldRestoreScrollPosition = m_currentItem->shouldRestoreScrollPosition();
 
+    // Get a HistoryItem tree for the current frame tree.
+    Ref<HistoryItem> topItem = m_frame.mainFrame().loader().history().createItemTree(m_frame, false);
+
     auto* document = m_frame.document();
     if (document && !document->hasRecentUserInteractionForNavigationFromJS())
         m_currentItem->setWasCreatedByJSWithoutUserInteraction(true);
-
-    // Get a HistoryItem tree for the current frame tree.
-    Ref<HistoryItem> topItem = m_frame.mainFrame().loader().history().createItemTree(m_frame, false);
 
     // Override data in the current item (created by createItemTree) to reflect
     // the pushState() arguments.

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/ImageLoader.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/ImageLoader.cpp
@@ -214,7 +214,7 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
         } else {
             if (m_lazyImageLoadState == LazyImageLoadState::None && isImageElement) {
                 auto& imageElement = downcast<HTMLImageElement>(element());
-                if (imageElement.isLazyLoadable() && document.settings().lazyImageLoadingEnabled()) {
+                if (imageElement.isLazyLoadable() && document.lazyImageLoadingEnabled()) {
                     m_lazyImageLoadState = LazyImageLoadState::Deferred;
                     request.setIgnoreForRequestCount(true);
                 }

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/ResourceLoader.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/ResourceLoader.cpp
@@ -262,7 +262,7 @@ void ResourceLoader::start()
 
     bool isMainFrameNavigation = frame() && frame()->isMainFrame() && options().mode == FetchOptions::Mode::Navigate;
 
-    m_handle = ResourceHandle::create(frameLoader()->networkingContext(), m_request, this, m_defersLoading, m_options.sniffContent == ContentSniffingPolicy::SniffContent, m_options.sniffContentEncoding == ContentEncodingSniffingPolicy::Sniff, WTFMove(sourceOrigin), isMainFrameNavigation);
+    m_handle = ResourceHandle::create(frameLoader()->networkingContext(), m_request, this, m_defersLoading, m_options.sniffContent == ContentSniffingPolicy::SniffContent, m_options.contentEncodingSniffingPolicy, WTFMove(sourceOrigin), isMainFrameNavigation);
 }
 
 void ResourceLoader::setDefersLoading(bool defers)

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/ResourceLoader.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/ResourceLoader.h
@@ -130,7 +130,7 @@ public:
     bool shouldSendResourceLoadCallbacks() const { return m_options.sendLoadCallbacks == SendCallbackPolicy::SendCallbacks; }
     void setSendCallbackPolicy(SendCallbackPolicy sendLoadCallbacks) { m_options.sendLoadCallbacks = sendLoadCallbacks; }
     bool shouldSniffContent() const { return m_options.sniffContent == ContentSniffingPolicy::SniffContent; }
-    bool shouldSniffContentEncoding() const { return m_options.sniffContentEncoding == ContentEncodingSniffingPolicy::Sniff; }
+    ContentEncodingSniffingPolicy contentEncodingSniffingPolicy() const { return m_options.contentEncodingSniffingPolicy; }
     WEBCORE_EXPORT bool isAllowedToAskUserForCredentials() const;
     WEBCORE_EXPORT bool shouldIncludeCertificateInfo() const;
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/ResourceLoaderOptions.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/ResourceLoaderOptions.h
@@ -126,11 +126,9 @@ enum class ApplicationCacheMode : uint8_t {
 };
 static constexpr unsigned bitWidthOfApplicationCacheMode = 1;
 
-// FIXME: These options are named poorly. We only implement force disabling content encoding sniffing, not enabling it,
-// and even that only on some platforms.
 enum class ContentEncodingSniffingPolicy : bool {
-    Sniff,
-    DoNotSniff
+    Default,
+    Disable
 };
 static constexpr unsigned bitWidthOfContentEncodingSniffingPolicy = 1;
 
@@ -163,7 +161,7 @@ struct ResourceLoaderOptions : public FetchOptions {
         : FetchOptions { WTFMove(options) }
         , sendLoadCallbacks(SendCallbackPolicy::DoNotSendCallbacks)
         , sniffContent(ContentSniffingPolicy::DoNotSniffContent)
-        , sniffContentEncoding(ContentEncodingSniffingPolicy::Sniff)
+        , contentEncodingSniffingPolicy(ContentEncodingSniffingPolicy::Default)
         , dataBufferingPolicy(DataBufferingPolicy::BufferData)
         , storedCredentialsPolicy(StoredCredentialsPolicy::DoNotUse)
         , securityCheck(SecurityCheckPolicy::DoSecurityCheck)
@@ -184,7 +182,7 @@ struct ResourceLoaderOptions : public FetchOptions {
     ResourceLoaderOptions(SendCallbackPolicy sendLoadCallbacks, ContentSniffingPolicy sniffContent, DataBufferingPolicy dataBufferingPolicy, StoredCredentialsPolicy storedCredentialsPolicy, ClientCredentialPolicy credentialPolicy, FetchOptions::Credentials credentials, SecurityCheckPolicy securityCheck, FetchOptions::Mode mode, CertificateInfoPolicy certificateInfoPolicy, ContentSecurityPolicyImposition contentSecurityPolicyImposition, DefersLoadingPolicy defersLoadingPolicy, CachingPolicy cachingPolicy)
         : sendLoadCallbacks(sendLoadCallbacks)
         , sniffContent(sniffContent)
-        , sniffContentEncoding(ContentEncodingSniffingPolicy::Sniff)
+        , contentEncodingSniffingPolicy(ContentEncodingSniffingPolicy::Default)
         , dataBufferingPolicy(dataBufferingPolicy)
         , storedCredentialsPolicy(storedCredentialsPolicy)
         , securityCheck(securityCheck)
@@ -218,7 +216,7 @@ struct ResourceLoaderOptions : public FetchOptions {
 
     SendCallbackPolicy sendLoadCallbacks : bitWidthOfSendCallbackPolicy;
     ContentSniffingPolicy sniffContent : bitWidthOfContentSniffingPolicy;
-    ContentEncodingSniffingPolicy sniffContentEncoding : bitWidthOfContentEncodingSniffingPolicy;
+    ContentEncodingSniffingPolicy contentEncodingSniffingPolicy : bitWidthOfContentEncodingSniffingPolicy;
     DataBufferingPolicy dataBufferingPolicy : bitWidthOfDataBufferingPolicy;
     StoredCredentialsPolicy storedCredentialsPolicy : bitWidthOfStoredCredentialsPolicy;
     SecurityCheckPolicy securityCheck : bitWidthOfSecurityCheckPolicy;

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/SubframeLoader.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/SubframeLoader.cpp
@@ -279,6 +279,9 @@ RefPtr<Frame> FrameLoader::SubframeLoader::loadSubframe(HTMLFrameOwnerElement& o
     if (!m_frame.page() || m_frame.page()->subframeCount() >= Page::maxNumberOfFrames)
         return nullptr;
 
+    if (m_frame.tree().depth() >= Page::maxFrameDepth)
+        return nullptr;
+
     // Prevent initial empty document load from triggering load events.
     document->incrementLoadEventDelayCount();
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/ThreadableLoader.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/ThreadableLoader.cpp
@@ -83,6 +83,7 @@ ThreadableLoaderOptions ThreadableLoaderOptions::isolatedCopy() const
     // ResourceLoaderOptions
     copy.sendLoadCallbacks = this->sendLoadCallbacks;
     copy.sniffContent = this->sniffContent;
+    copy.contentEncodingSniffingPolicy = this->contentEncodingSniffingPolicy;
     copy.dataBufferingPolicy = this->dataBufferingPolicy;
     copy.storedCredentialsPolicy = this->storedCredentialsPolicy;
     copy.securityCheck = this->securityCheck;

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/appcache/DOMApplicationCache.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/appcache/DOMApplicationCache.cpp
@@ -87,10 +87,10 @@ void DOMApplicationCache::abort()
 
 ScriptExecutionContext* DOMApplicationCache::scriptExecutionContext() const
 {
-    auto* frame = this->frame();
-    if (!frame)
+    auto* window = this->window();
+    if (!window)
         return nullptr;
-    return frame->document();
+    return window->document();
 }
 
 } // namespace WebCore

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/Chrome.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/Chrome.cpp
@@ -29,8 +29,6 @@
 #include "DOMWindow.h"
 #include "Document.h"
 #include "DocumentType.h"
-#include "FileChooser.h"
-#include "FileIconLoader.h"
 #include "FileList.h"
 #include "FloatRect.h"
 #include "Frame.h"

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/EventHandler.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/EventHandler.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2006-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2013 Google Inc. All rights reserved.
  * Copyright (C) 2006 Alexey Proskuryakov (ap@webkit.org)
  * Copyright (C) 2012 Digia Plc. and/or its subsidiary(-ies)
  *
@@ -430,6 +431,7 @@ void EventHandler::clear()
     m_originatingTouchPointTargets.clear();
     m_originatingTouchPointDocument = nullptr;
     m_originatingTouchPointTargetKey = 0;
+    m_touchPressed = false;
 #endif
     m_maxMouseMovedDuration = 0;
     m_didStartDrag = false;

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/FrameTree.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/FrameTree.cpp
@@ -459,6 +459,14 @@ Frame& FrameTree::top() const
     return *frame;
 }
 
+unsigned FrameTree::depth() const
+{
+    unsigned depth = 0;
+    for (auto* parent = &m_thisFrame; parent; parent = parent->tree().parent())
+        depth++;
+    return depth;
+}
+
 ASCIILiteral blankTargetFrameName()
 {
     return "_blank"_s;

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/FrameTree.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/FrameTree.h
@@ -74,6 +74,7 @@ public:
     WEBCORE_EXPORT unsigned childCount() const;
     unsigned descendantCount() const;
     WEBCORE_EXPORT Frame& top() const;
+    unsigned depth() const;
 
     WEBCORE_EXPORT Frame* scopedChild(unsigned index) const;
     WEBCORE_EXPORT Frame* scopedChild(const AtomString& name) const;

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/FrameView.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/FrameView.cpp
@@ -3576,7 +3576,12 @@ void FrameView::performPostLayoutTasks()
     // FIXME: We should not run any JavaScript code in this function.
     LOG(Layout, "FrameView %p performPostLayoutTasks", this);
     updateHasReachedSignificantRenderedTextThreshold();
-    frame().selection().updateAppearanceAfterLayout();
+
+    if (auto& selection = frame().selection(); selection.isFocusedAndActive()) {
+        // FIXME (247041): We should be able to remove this appearance update altogether,
+        // and instead defer updates until the next rendering update.
+        selection.updateAppearanceAfterLayout();
+    }
 
     flushPostLayoutTasksQueue();
 
@@ -5362,6 +5367,20 @@ String FrameView::trackedRepaintRectsAsText() const
         ts << ")\n";
     }
     return ts.release();
+}
+
+void FrameView::addScrollableAreaForAnimatedScroll(ScrollableArea* scrollableArea)
+{
+    if (!m_scrollableAreasForAnimatedScroll)
+        m_scrollableAreasForAnimatedScroll = makeUnique<ScrollableAreaSet>();
+
+    m_scrollableAreasForAnimatedScroll->add(scrollableArea);
+}
+
+void FrameView::removeScrollableAreaForAnimatedScroll(ScrollableArea* scrollableArea)
+{
+    if (m_scrollableAreasForAnimatedScroll)
+        m_scrollableAreasForAnimatedScroll->remove(scrollableArea);
 }
 
 bool FrameView::addScrollableArea(ScrollableArea* scrollableArea)

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/FrameView.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/FrameView.h
@@ -595,6 +595,10 @@ public:
     bool containsScrollableArea(ScrollableArea*) const;
     const ScrollableAreaSet* scrollableAreas() const { return m_scrollableAreas.get(); }
 
+    void addScrollableAreaForAnimatedScroll(ScrollableArea*);
+    void removeScrollableAreaForAnimatedScroll(ScrollableArea*);
+    const ScrollableAreaSet* scrollableAreasForAnimatedScroll() const { return m_scrollableAreasForAnimatedScroll.get(); }
+
     WEBCORE_EXPORT void addChild(Widget&) final;
     WEBCORE_EXPORT void removeChild(Widget&) final;
 
@@ -977,6 +981,7 @@ private:
     IntSize m_autoSizeContentSize;
 
     std::unique_ptr<ScrollableAreaSet> m_scrollableAreas;
+    std::unique_ptr<ScrollableAreaSet> m_scrollableAreasForAnimatedScroll;
     std::unique_ptr<WeakHashSet<RenderLayerModelObject>> m_viewportConstrainedObjects;
 
     OptionSet<LayoutMilestone> m_milestonesPendingPaint;

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/Page.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/Page.cpp
@@ -593,7 +593,7 @@ Ref<DOMRectList> Page::passiveTouchEventListenerRectsForTesting()
 
 void Page::settingsDidChange()
 {
-#if USE(LIBWEBRTC)
+#if ENABLE(WEB_RTC)
     m_webRTCProvider->setH265Support(settings().webRTCH265CodecEnabled());
     m_webRTCProvider->setVP9Support(settings().webRTCVP9Profile0CodecEnabled(), settings().webRTCVP9Profile2CodecEnabled());
 #endif

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/Page.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/Page.h
@@ -686,7 +686,10 @@ public:
     // This seems like a reasonable upper bound, and otherwise mutually
     // recursive frameset pages can quickly bring the program to its knees
     // with exponential growth in the number of frames.
-    static const int maxNumberOfFrames = 1000;
+    static constexpr int maxNumberOfFrames = 1000;
+
+    // Don't allow more than a certain frame depth to avoid stack exhaustion.
+    static constexpr int maxFrameDepth = 32;
 
     void setEditable(bool isEditable) { m_isEditable = isEditable; }
     bool isEditable() const { return m_isEditable; }

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/Quirks.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/Quirks.cpp
@@ -37,6 +37,7 @@
 #include "EventNames.h"
 #include "FrameLoader.h"
 #include "HTMLBodyElement.h"
+#include "HTMLCollection.h"
 #include "HTMLDivElement.h"
 #include "HTMLMetaElement.h"
 #include "HTMLObjectElement.h"
@@ -148,19 +149,6 @@ bool Quirks::needsPerDocumentAutoplayBehavior() const
 #endif
 }
 
-bool Quirks::shouldAutoplayForArbitraryUserGesture() const
-{
-#if PLATFORM(MAC)
-    return needsQuirks() && allowedAutoplayQuirks(*m_document).contains(AutoplayQuirk::ArbitraryUserGestures);
-#else
-    if (!needsQuirks())
-        return false;
-
-    auto domain = RegistrableDomain { m_document->topDocument().url() };
-    return domain == "twitter.com"_s || domain == "facebook.com"_s;
-#endif
-}
-
 bool Quirks::shouldAutoplayWebAudioForArbitraryUserGesture() const
 {
     if (!needsQuirks())
@@ -225,14 +213,6 @@ bool Quirks::shouldHideSearchFieldResultsButton() const
     return false;
 }
 
-bool Quirks::shouldDisableResolutionMediaQuery() const
-{
-    if (!needsQuirks())
-        return false;
-    auto host = m_document->url().host();
-    return equalLettersIgnoringASCIICase(host, "www.hotels.com"_s);
-}
-
 bool Quirks::needsMillisecondResolutionForHighResTimeStamp() const
 {
     if (!needsQuirks())
@@ -240,15 +220,6 @@ bool Quirks::needsMillisecondResolutionForHighResTimeStamp() const
     // webkit.org/b/210527
     auto host = m_document->url().host();
     return equalLettersIgnoringASCIICase(host, "www.icourse163.org"_s);
-}
-
-bool Quirks::shouldStripQuotationMarkInFontFaceSetFamily() const
-{
-    if (!needsQuirks())
-        return false;
-
-    auto host = m_document->topDocument().url().host();
-    return equalLettersIgnoringASCIICase(host, "docs.google.com"_s);
 }
 
 bool Quirks::isTouchBarUpdateSupressedForHiddenContentEditable() const
@@ -394,8 +365,6 @@ bool Quirks::shouldDispatchSimulatedMouseEvents(const EventTarget* target) const
             return startsWithLettersIgnoringASCIICase(url.path(), "/website/templates/"_s) ? ShouldDispatchSimulatedMouseEvents::No : ShouldDispatchSimulatedMouseEvents::Yes;
         }
 
-        if ((host == "desmos.com"_s || host.endsWith(".desmos.com"_s)) && startsWithLettersIgnoringASCIICase(url.path(), "/calculator/"_s))
-            return ShouldDispatchSimulatedMouseEvents::Yes;
         if (host == "trello.com"_s || host.endsWith(".trello.com"_s))
             return ShouldDispatchSimulatedMouseEvents::Yes;
         if (host == "airtable.com"_s || host.endsWith(".airtable.com"_s))
@@ -1296,34 +1265,6 @@ bool Quirks::needsHDRPixelDepthQuirk() const
     return *m_needsHDRPixelDepthQuirk;
 }
 
-// FIXME: remove this once rdar://66739450 has been fixed.
-bool Quirks::needsAkamaiMediaPlayerQuirk(const HTMLVideoElement& element) const
-{
-#if PLATFORM(IOS_FAMILY)
-    // Akamai Media Player begins polling `webkitDisplayingFullscreen` every 100ms immediately after calling
-    // `webkitEnterFullscreen` and exits fullscreen as soon as it returns false. r262456 changed the HTMLMediaPlayer state
-    // machine so `webkitDisplayingFullscreen` doesn't return true until the fullscreen window has been opened in the
-    // UI process, which causes Akamai Media Player to frequently exit fullscreen mode immediately.
-
-    static NeverDestroyed<const AtomString> akamaiHTML5(MAKE_STATIC_STRING_IMPL("akamai-html5"));
-    static NeverDestroyed<const AtomString> akamaiMediaElement(MAKE_STATIC_STRING_IMPL("akamai-media-element"));
-    static NeverDestroyed<const AtomString> ampHTML5(MAKE_STATIC_STRING_IMPL("amp-html5"));
-    static NeverDestroyed<const AtomString> ampMediaElement(MAKE_STATIC_STRING_IMPL("amp-media-element"));
-
-    if (!needsQuirks())
-        return false;
-
-    if (!element.hasClass())
-        return false;
-
-    auto& classNames = element.classNames();
-    return (classNames.contains(akamaiHTML5) && classNames.contains(akamaiMediaElement)) || (classNames.contains(ampHTML5) && classNames.contains(ampMediaElement));
-#else
-    UNUSED_PARAM(element);
-    return false;
-#endif
-}
-
 // FIXME: remove this once rdar://92531240 has been fixed.
 bool Quirks::needsFlightAwareSerializationQuirk() const
 {
@@ -1334,21 +1275,6 @@ bool Quirks::needsFlightAwareSerializationQuirk() const
         m_needsFlightAwareSerializationQuirk = equalLettersIgnoringASCIICase(m_document->url().host(), "flightaware.com"_s);
 
     return *m_needsFlightAwareSerializationQuirk;
-}
-
-bool Quirks::needsBlackFullscreenBackgroundQuirk() const
-{
-    // MLB.com sets a black background-color on the :backdrop pseudo element, which WebKit does not yet support. This
-    // quirk can be removed once support for :backdrop psedue element is added.
-    if (!needsQuirks())
-        return false;
-
-    if (!m_needsBlackFullscreenBackgroundQuirk) {
-        auto host = m_document->topDocument().url().host();
-        m_needsBlackFullscreenBackgroundQuirk = equalLettersIgnoringASCIICase(host, "mlb.com"_s) || host.endsWithIgnoringASCIICase(".mlb.com"_s);
-    }
-
-    return *m_needsBlackFullscreenBackgroundQuirk;
 }
 
 bool Quirks::requiresUserGestureToPauseInPictureInPicture() const
@@ -1529,9 +1455,39 @@ bool Quirks::shouldExposeShowModalDialog() const
         return false;
     if (!m_shouldExposeShowModalDialog) {
         auto domain = RegistrableDomain(m_document->url()).string();
-        m_shouldExposeShowModalDialog = domain == "pandora.com"_s;
+        // Marcus: <rdar://101086391>.
+        // Pandora: <rdar://100243111>.
+        // Soundcloud: <rdar://102913500>.
+        m_shouldExposeShowModalDialog = domain == "pandora.com"_s || domain == "marcus.com"_s || domain == "soundcloud.com"_s;
     }
     return *m_shouldExposeShowModalDialog;
+}
+
+bool Quirks::shouldDisableLazyImageLoadingQuirk() const
+{
+    // Images are displaying as fully grey when loaded lazily in significant percentage of page loads.
+    // This issue is not observed when lazy image loading is disabled, and has been fixed in future Gatsby versions.
+    // This quirk is only applied to IKEA.com when "<meta name="generator" content="Gatsby 4.24.1" />" is present.
+    // This quirk can be removed once the gatsby version has been upgraded.
+    // Further discussion can be found here https://github.com/webcompat/web-bugs/issues/113635.
+
+    if (!needsQuirks())
+        return false;
+
+    if (m_shouldDisableLazyImageLoadingQuirk)
+        return m_shouldDisableLazyImageLoadingQuirk.value();
+
+    m_shouldDisableLazyImageLoadingQuirk = false;
+
+    if (RegistrableDomain(m_document->url()).string() != "ikea.com"_s)
+        return false;
+
+    auto* metaElement = m_document->getElementsByTagName("meta"_s)->namedItem("generator"_s);
+
+    if (metaElement && metaElement->getAttribute("content"_s) == "Gatsby 4.24.1"_s)
+        m_shouldDisableLazyImageLoadingQuirk = true;
+
+    return m_shouldDisableLazyImageLoadingQuirk.value();
 }
 
 }

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/Quirks.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/Quirks.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "Event.h"
+#include <optional>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -60,10 +61,8 @@ public:
     bool needsAutoplayPlayPauseEvents() const;
     bool needsSeekingSupportDisabled() const;
     bool needsPerDocumentAutoplayBehavior() const;
-    bool shouldAutoplayForArbitraryUserGesture() const;
     bool shouldAutoplayWebAudioForArbitraryUserGesture() const;
     bool hasBrokenEncryptedMediaAPISupportQuirk() const;
-    bool shouldStripQuotationMarkInFontFaceSetFamily() const;
 #if ENABLE(TOUCH_EVENTS)
     bool shouldDispatchSimulatedMouseEvents(const EventTarget*) const;
     bool shouldDispatchedSimulatedMouseEventsAssumeDefaultPrevented(EventTarget*) const;
@@ -81,7 +80,6 @@ public:
     bool shouldDisableContentChangeObserverTouchEventAdjustment() const;
     bool shouldTooltipPreventFromProceedingWithClick(const Element&) const;
     bool shouldHideSearchFieldResultsButton() const;
-    bool shouldDisableResolutionMediaQuery() const;
     bool shouldExposeShowModalDialog() const;
 
     bool needsMillisecondResolutionForHighResTimeStamp() const;
@@ -133,10 +131,7 @@ public:
     bool needsVP9FullRangeFlagQuirk() const;
     bool needsHDRPixelDepthQuirk() const;
 
-    bool needsAkamaiMediaPlayerQuirk(const HTMLVideoElement&) const;
     bool needsFlightAwareSerializationQuirk() const;
-
-    bool needsBlackFullscreenBackgroundQuirk() const;
 
     bool requiresUserGestureToPauseInPictureInPicture() const;
     bool requiresUserGestureToLoadInPictureInPicture() const;
@@ -164,6 +159,8 @@ public:
     bool hasBrokenPermissionsAPISupportQuirk() const;
     bool shouldEnableApplicationCacheQuirk() const;
     bool needsVideoShouldMaintainAspectRatioQuirk() const;
+
+    bool shouldDisableLazyImageLoadingQuirk() const;
 
 private:
     bool needsQuirks() const;
@@ -219,6 +216,7 @@ private:
 #endif
     mutable std::optional<bool> m_needsVideoShouldMaintainAspectRatioQuirk;
     mutable std::optional<bool> m_shouldExposeShowModalDialog;
+    mutable std::optional<bool> m_shouldDisableLazyImageLoadingQuirk;
 };
 
 } // namespace WebCore

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -165,9 +165,20 @@ void ContentSecurityPolicy::didCreateWindowProxy(JSWindowProxy& windowProxy) con
 ContentSecurityPolicyResponseHeaders ContentSecurityPolicy::responseHeaders() const
 {
     if (!m_cachedResponseHeaders) {
+        auto makeValidHTTPHeaderIfNeeded = [this](auto& header) {
+            // If coming from an existing HTTP header it should be valid already.
+            if (m_isHeaderDelivered)
+                return header;
+
+            // Newlines are valid in http-equiv but not in HTTP header value.
+            auto returnValue = makeStringByReplacingAll(header, '\n', ""_s);
+            returnValue = makeStringByReplacingAll(returnValue, '\r', ""_s);
+            return returnValue;
+        };
+
         ContentSecurityPolicyResponseHeaders result;
-        result.m_headers = m_policies.map([](auto& policy) {
-            return std::pair { policy->header(), policy->headerType() };
+        result.m_headers = m_policies.map([&makeValidHTTPHeaderIfNeeded](auto& policy) {
+            return std::pair { makeValidHTTPHeaderIfNeeded(policy->header()), policy->headerType() };
         });
         result.m_httpStatusCode = m_httpStatusCode;
         m_cachedResponseHeaders = WTFMove(result);

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -30,6 +30,7 @@
 #include "ContentSecurityPolicyDirectiveNames.h"
 #include "Document.h"
 #include "Frame.h"
+#include "HTTPParsers.h"
 #include "ParsingUtilities.h"
 #include "SecurityContext.h"
 #include <wtf/text/StringParsingBuffer.h>
@@ -433,7 +434,15 @@ const ContentSecurityPolicyDirective* ContentSecurityPolicyDirectiveList::violat
 //
 void ContentSecurityPolicyDirectiveList::parse(const String& policy, ContentSecurityPolicy::PolicyFrom policyFrom)
 {
+    // A meta tag delievered CSP could contain invalid HTTP header values depending on how it was formatted in the document.
+    // We want to store the CSP as a valid HTTP header for e.g. blob URL inheritance.
+    if (policyFrom == ContentSecurityPolicy::PolicyFrom::HTTPEquivMeta) {
+        m_header = stripLeadingAndTrailingHTTPSpaces(policy).removeCharacters([](auto c) {
+            return c == 0x00 || c == '\r' || c == '\n';
+        });
+    } else
     m_header = policy;
+
     if (policy.isEmpty())
         return;
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -443,8 +443,10 @@ void AsyncScrollingCoordinator::animatedScrollDidEndForNode(ScrollingNodeID scro
         return;
     }
 
-    if (auto* scrollableArea = frameView->scrollableAreaForScrollingNodeID(scrollingNodeID))
+    if (auto* scrollableArea = frameView->scrollableAreaForScrollingNodeID(scrollingNodeID)) {
         scrollableArea->setScrollAnimationStatus(ScrollAnimationStatus::NotAnimating);
+        scrollableArea->animatedScrollDidEnd();
+    }
 }
 
 void AsyncScrollingCoordinator::updateScrollPositionAfterAsyncScroll(ScrollingNodeID scrollingNodeID, const FloatPoint& scrollPosition, std::optional<FloatPoint> layoutViewportOrigin, ScrollingLayerPositionAction scrollingLayerPositionAction, ScrollType scrollType)

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/FileChooser.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/FileChooser.cpp
@@ -31,13 +31,13 @@
 
 namespace WebCore {
 
-FileChooser::FileChooser(FileChooserClient* client, const FileChooserSettings& settings)
-    : m_client(client)
+FileChooser::FileChooser(FileChooserClient& client, const FileChooserSettings& settings)
+    : m_client(&client)
     , m_settings(settings)
 {
 }
 
-Ref<FileChooser> FileChooser::create(FileChooserClient* client, const FileChooserSettings& settings)
+Ref<FileChooser> FileChooser::create(FileChooserClient& client, const FileChooserSettings& settings)
 {
     return adoptRef(*new FileChooser(client, settings));
 }
@@ -74,8 +74,6 @@ void FileChooser::chooseFiles(const Vector<String>& filenames, const Vector<Stri
 
 #if PLATFORM(IOS_FAMILY)
 
-// FIXME: This function is almost identical to FileChooser::chooseFiles(). We should merge this function
-// with FileChooser::chooseFiles() and hence remove the PLATFORM(IOS_FAMILY)-guard.
 void FileChooser::chooseMediaFiles(const Vector<String>& filenames, const String& displayString, Icon* icon)
 {
     // FIXME: This is inelegant. We should not be looking at settings here.

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/FileChooser.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/FileChooser.h
@@ -36,14 +36,13 @@
 
 namespace WebCore {
 
-enum MediaCaptureType {
+class Icon;
+
+enum class MediaCaptureType : uint8_t {
     MediaCaptureTypeNone,
     MediaCaptureTypeUser,
     MediaCaptureTypeEnvironment
 };
-
-class FileChooser;
-class Icon;
 
 struct FileChooserFileInfo {
     FileChooserFileInfo isolatedCopy() const & { return { path.isolatedCopy(), replacementPath.isolatedCopy(), displayName.isolatedCopy() }; }
@@ -61,7 +60,7 @@ struct FileChooserSettings {
     Vector<String> acceptFileExtensions;
     Vector<String> selectedFiles;
 #if ENABLE(MEDIA_CAPTURE)
-    MediaCaptureType mediaCaptureType { MediaCaptureTypeNone };
+    MediaCaptureType mediaCaptureType { MediaCaptureType::MediaCaptureTypeNone };
 #endif
 };
 
@@ -74,7 +73,7 @@ public:
 
 class FileChooser : public RefCounted<FileChooser> {
 public:
-    static Ref<FileChooser> create(FileChooserClient*, const FileChooserSettings&);
+    static Ref<FileChooser> create(FileChooserClient&, const FileChooserSettings&);
     WEBCORE_EXPORT ~FileChooser();
 
     void invalidate();
@@ -82,8 +81,7 @@ public:
     WEBCORE_EXPORT void chooseFile(const String& path);
     WEBCORE_EXPORT void chooseFiles(const Vector<String>& paths, const Vector<String>& replacementPaths = { });
 #if PLATFORM(IOS_FAMILY)
-    // FIXME: This function is almost identical to FileChooser::chooseFiles(). We should merge this
-    // function with FileChooser::chooseFiles() and hence remove the PLATFORM(IOS_FAMILY)-guard.
+    // FIXME: This function is almost identical to FileChooser::chooseFiles(). We should merge this in and remove this one.
     WEBCORE_EXPORT void chooseMediaFiles(const Vector<String>& paths, const String& displayString, Icon*);
 #endif
 
@@ -93,7 +91,7 @@ public:
     const FileChooserSettings& settings() const { return m_settings; }
 
 private:
-    FileChooser(FileChooserClient*, const FileChooserSettings&);
+    FileChooser(FileChooserClient&, const FileChooserSettings&);
 
     FileChooserClient* m_client { nullptr };
     FileChooserSettings m_settings;

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/GStreamer.cmake
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/GStreamer.cmake
@@ -4,6 +4,7 @@ if (ENABLE_VIDEO OR ENABLE_WEB_AUDIO)
         "${WEBCORE_DIR}/platform/graphics/gstreamer"
         "${WEBCORE_DIR}/platform/graphics/gstreamer/mse"
         "${WEBCORE_DIR}/platform/graphics/gstreamer/eme"
+        "${WEBCORE_DIR}/platform/gstreamer"
         "${WEBCORE_DIR}/platform/mediarecorder/gstreamer"
     )
 
@@ -64,6 +65,8 @@ if (ENABLE_VIDEO OR ENABLE_WEB_AUDIO)
         platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
         platform/graphics/gstreamer/mse/TrackQueue.cpp
         platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+
+        platform/gstreamer/GStreamerCodecUtilities.cpp
 
         platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/NowPlayingManager.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/NowPlayingManager.cpp
@@ -82,9 +82,9 @@ bool NowPlayingManager::setNowPlayingInfo(const NowPlayingInfo& nowPlayingInfo)
     if (!nowPlayingInfo.artwork)
         m_nowPlayingInfoArtwork = { };
     else if (!m_nowPlayingInfoArtwork || nowPlayingInfo.artwork->src != m_nowPlayingInfoArtwork->src)
-        m_nowPlayingInfoArtwork = ArtworkCache { nowPlayingInfo.artwork->src, nowPlayingInfo.artwork->imageData };
+        m_nowPlayingInfoArtwork = ArtworkCache { nowPlayingInfo.artwork->src, nowPlayingInfo.artwork->image };
     else
-        m_nowPlayingInfo->artwork->imageData = nullptr;
+        m_nowPlayingInfo->artwork->image = nullptr;
 
     setNowPlayingInfoPrivate(*m_nowPlayingInfo);
     m_setAsNowPlayingApplication = true;
@@ -95,10 +95,10 @@ void NowPlayingManager::setNowPlayingInfoPrivate(const NowPlayingInfo& nowPlayin
 {
     setSupportsSeeking(nowPlayingInfo.supportsSeeking);
 #if PLATFORM(COCOA)
-    if (nowPlayingInfo.artwork && !nowPlayingInfo.artwork->imageData) {
+    if (nowPlayingInfo.artwork && !nowPlayingInfo.artwork->image) {
         ASSERT(m_nowPlayingInfoArtwork, "cached value must have been initialized");
         NowPlayingInfo nowPlayingInfoRebuilt = nowPlayingInfo;
-        nowPlayingInfoRebuilt.artwork->imageData = m_nowPlayingInfoArtwork->imageData;
+        nowPlayingInfoRebuilt.artwork->image = m_nowPlayingInfoArtwork->image;
         MediaSessionManagerCocoa::setNowPlayingInfo(!m_setAsNowPlayingApplication, nowPlayingInfoRebuilt);
         return;
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/NowPlayingManager.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/NowPlayingManager.h
@@ -32,6 +32,7 @@
 
 namespace WebCore {
 
+class Image;
 struct NowPlayingInfo;
 
 class WEBCORE_EXPORT NowPlayingManager : public RemoteCommandListenerClient {
@@ -70,7 +71,7 @@ private:
     std::optional<NowPlayingInfo> m_nowPlayingInfo;
     struct ArtworkCache {
         String src;
-        RefPtr<FragmentedSharedBuffer> imageData;
+        RefPtr<Image> image;
     };
     std::optional<ArtworkCache> m_nowPlayingInfoArtwork;
     bool m_setAsNowPlayingApplication { false };

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/ScrollAnimator.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/ScrollAnimator.cpp
@@ -283,6 +283,7 @@ void ScrollAnimator::willStartAnimatedScroll()
 void ScrollAnimator::didStopAnimatedScroll()
 {
     m_scrollableArea.setScrollAnimationStatus(ScrollAnimationStatus::NotAnimating);
+    m_scrollableArea.animatedScrollDidEnd();
 }
 
 #if HAVE(RUBBER_BANDING)

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/ScrollTypes.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/ScrollTypes.h
@@ -406,4 +406,14 @@ template<> struct EnumTraits<WebCore::ScrollGranularity> {
         WebCore::ScrollGranularity::Pixel
     >;
 };
+
+template<> struct EnumTraits<WebCore::ScrollDirection> {
+    using values = EnumValues<
+        WebCore::ScrollDirection,
+        WebCore::ScrollDirection::ScrollUp,
+        WebCore::ScrollDirection::ScrollDown,
+        WebCore::ScrollDirection::ScrollLeft,
+        WebCore::ScrollDirection::ScrollRight
+    >;
+};
 } // namespace WTF

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/ScrollableArea.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/ScrollableArea.h
@@ -280,6 +280,7 @@ public:
     // This reflects animated scrolls triggered by CSS OM View "smooth" scrolls.
     ScrollAnimationStatus scrollAnimationStatus() { return m_scrollAnimationStatus; }
     void setScrollAnimationStatus(ScrollAnimationStatus status) { m_scrollAnimationStatus = status; }
+    virtual void animatedScrollDidEnd() { };
 
     bool scrollShouldClearLatchedState() const { return m_scrollShouldClearLatchedState; }
     void setScrollShouldClearLatchedState(bool shouldClear) { m_scrollShouldClearLatchedState = shouldClear; }
@@ -386,6 +387,7 @@ public:
     bool overscrollBehaviorAllowsRubberBand() const { return horizontalOverscrollBehavior() != OverscrollBehavior::None || verticalOverscrollBehavior() != OverscrollBehavior::None; }
     bool shouldBlockScrollPropagation(const FloatSize&) const;
     FloatSize deltaForPropagation(const FloatSize&) const;
+    virtual bool needsAnimatedScroll() const { return false; }
 
 protected:
     WEBCORE_EXPORT ScrollableArea();

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/ThreadGlobalData.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/ThreadGlobalData.cpp
@@ -51,6 +51,9 @@ ThreadGlobalData::~ThreadGlobalData() = default;
 
 void ThreadGlobalData::destroy()
 {
+    if (m_fontCache)
+        m_fontCache->invalidate();
+    m_fontCache = nullptr;
     m_destroyed = true;
 }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/ThreadGlobalData.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/ThreadGlobalData.h
@@ -106,6 +106,8 @@ public:
     FontCache* fontCacheIfNotDestroyed() { return m_destroyed ? nullptr : &fontCache(); }
 
 private:
+    bool m_destroyed { false };
+
     WEBCORE_EXPORT void initializeCachedResourceRequestInitiators();
     WEBCORE_EXPORT void initializeEventNames();
     WEBCORE_EXPORT void initializeQualifiedNameCache();
@@ -125,7 +127,6 @@ private:
 #endif
 
     bool m_isInRemoveAllEventListeners { false };
-    bool m_destroyed { false };
 
     WEBCORE_EXPORT friend ThreadGlobalData& threadGlobalData();
 };

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/adwaita/ThemeAdwaita.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/adwaita/ThemeAdwaita.cpp
@@ -132,19 +132,34 @@ void ThemeAdwaita::paintFocus(GraphicsContext& graphicsContext, const Vector<Flo
     paintFocus(graphicsContext, path, color);
 }
 
-void ThemeAdwaita::paintArrow(GraphicsContext& graphicsContext, ArrowDirection direction, bool useDarkAppearance)
+void ThemeAdwaita::paintArrow(GraphicsContext& graphicsContext, const FloatRect& rect, ArrowDirection direction, bool useDarkAppearance)
 {
+    auto offset = rect.location();
+    float size;
+    if (rect.width() > rect.height()) {
+        size = rect.height();
+        offset.move((rect.width() - size) / 2, 0);
+    } else {
+        size = rect.width();
+        offset.move(0, (rect.height() - size) / 2);
+    }
+    float zoomFactor = size / arrowSize;
+    auto transform = [&](FloatPoint point) {
+        point.scale(zoomFactor);
+        point.moveBy(offset);
+        return point;
+    };
     Path path;
     switch (direction) {
     case ArrowDirection::Down:
-        path.moveTo({ 3, 6 });
-        path.addLineTo({ 13, 6 });
-        path.addLineTo({ 8, 11 });
+        path.moveTo(transform({ 3, 6 }));
+        path.addLineTo(transform({ 13, 6 }));
+        path.addLineTo(transform({ 8, 11 }));
         break;
     case ArrowDirection::Up:
-        path.moveTo({ 3, 10 });
-        path.addLineTo({ 8, 5 });
-        path.addLineTo({ 13, 10});
+        path.moveTo(transform({ 3, 10 }));
+        path.addLineTo(transform({ 8, 5 }));
+        path.addLineTo(transform({ 13, 10 }));
         break;
     }
     path.closeSubpath();
@@ -163,15 +178,15 @@ LengthSize ThemeAdwaita::controlSize(ControlPart part, const FontCascade& fontCa
     case RadioPart: {
         LengthSize buttonSize = zoomedSize;
         if (buttonSize.width.isIntrinsicOrAuto())
-            buttonSize.width = Length(12, LengthType::Fixed);
+            buttonSize.width = Length(12 * zoomFactor, LengthType::Fixed);
         if (buttonSize.height.isIntrinsicOrAuto())
-            buttonSize.height = Length(12, LengthType::Fixed);
+            buttonSize.height = Length(12 * zoomFactor, LengthType::Fixed);
         return buttonSize;
     }
     case InnerSpinButtonPart: {
         LengthSize spinButtonSize = zoomedSize;
         if (spinButtonSize.width.isIntrinsicOrAuto())
-            spinButtonSize.width = Length(static_cast<int>(arrowSize), LengthType::Fixed);
+            spinButtonSize.width = Length(static_cast<int>(arrowSize * zoomFactor), LengthType::Fixed);
         if (spinButtonSize.height.isIntrinsicOrAuto() || fontCascade.pixelSize() > static_cast<int>(arrowSize))
             spinButtonSize.height = Length(fontCascade.pixelSize(), LengthType::Fixed);
         return spinButtonSize;
@@ -492,14 +507,7 @@ void ThemeAdwaita::paintSpinButton(ControlStates& states, GraphicsContext& graph
             path.clear();
         }
 
-        GraphicsContextStateSaver buttonStateSaver(graphicsContext);
-        if (buttonRect.height() > arrowSize)
-            graphicsContext.translate(buttonRect.x(), buttonRect.y() + (buttonRect.height() / 2.0) - (arrowSize / 2.));
-        else {
-            graphicsContext.translate(buttonRect.x(), buttonRect.y());
-            graphicsContext.scale(FloatSize::narrowPrecision(buttonRect.width() / arrowSize, buttonRect.height() / arrowSize));
-        }
-        paintArrow(graphicsContext, ArrowDirection::Up, useDarkAppearance);
+        paintArrow(graphicsContext, buttonRect, ArrowDirection::Up, useDarkAppearance);
     }
 
     buttonRect.move(0, buttonRect.height());
@@ -510,18 +518,13 @@ void ThemeAdwaita::paintSpinButton(ControlStates& states, GraphicsContext& graph
                 graphicsContext.setFillColor(spinButtonBackgroundPressedColor);
             else if (states.states().contains(ControlStates::States::Hovered))
                 graphicsContext.setFillColor(spinButtonBackgroundHoveredColor);
+            else
+                graphicsContext.setFillColor(spinButtonBackgroundColor);
             graphicsContext.fillPath(path);
             path.clear();
         }
 
-        GraphicsContextStateSaver buttonStateSaver(graphicsContext);
-        if (buttonRect.height() > arrowSize)
-            graphicsContext.translate(buttonRect.x(), buttonRect.y() + (buttonRect.height() / 2.0) - (arrowSize / 2.));
-        else {
-            graphicsContext.translate(buttonRect.x(), buttonRect.y());
-            graphicsContext.scale(FloatSize::narrowPrecision(buttonRect.width() / arrowSize, buttonRect.height() / arrowSize));
-        }
-        paintArrow(graphicsContext, ArrowDirection::Down, useDarkAppearance);
+        paintArrow(graphicsContext, buttonRect, ArrowDirection::Down, useDarkAppearance);
     }
 }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/adwaita/ThemeAdwaita.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/adwaita/ThemeAdwaita.h
@@ -41,7 +41,7 @@ public:
     static void paintFocus(GraphicsContext&, const Path&, const Color&);
     static void paintFocus(GraphicsContext&, const Vector<FloatRect>&, const Color&, PaintRounded = PaintRounded::No);
     enum class ArrowDirection { Up, Down };
-    static void paintArrow(GraphicsContext&, ArrowDirection, bool);
+    static void paintArrow(GraphicsContext&, const FloatRect&, ArrowDirection, bool);
 
     virtual void platformColorsDidChange() { };
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/animation/TimingFunction.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/animation/TimingFunction.h
@@ -232,7 +232,7 @@ public:
         if (!m_stepPosition && *otherSteps.m_stepPosition == StepPosition::End)
             return true;
 
-        if (*m_stepPosition == StepPosition::End && !otherSteps.m_stepPosition)
+        if (!otherSteps.m_stepPosition && *m_stepPosition == StepPosition::End)
             return true;
 
         return false;

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/audio/NowPlayingInfo.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/audio/NowPlayingInfo.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
+#include "Image.h"
 #include "MediaUniqueIdentifier.h"
-#include "SharedBuffer.h"
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
@@ -36,7 +36,7 @@ namespace WebCore {
 struct NowPlayingInfoArtwork {
     String src;
     String mimeType;
-    RefPtr<FragmentedSharedBuffer> imageData;
+    RefPtr<Image> image;
 
     bool operator==(const NowPlayingInfoArtwork& other) const
     {
@@ -54,24 +54,20 @@ struct NowPlayingInfoArtwork {
 
 template<class Encoder> inline void NowPlayingInfoArtwork::encode(Encoder& encoder) const
 {
-    encoder << src << mimeType << imageData;
+    // Encoder of RefPtr<Image> will automatically decode the image and convert it to a BitmapImage/ShareableBitmap.
+    encoder << src << mimeType << image;
 }
 
 template<class Decoder> inline std::optional<NowPlayingInfoArtwork> NowPlayingInfoArtwork::decode(Decoder& decoder)
 {
-    String src;
-    if (!decoder.decode(src))
-        return { };
+    auto src = decoder.template decode<String>();
+    auto mimeType = decoder.template decode<String>();
+    auto image = decoder.template decode<RefPtr<Image>>();
 
-    String mimeType;
-    if (!decoder.decode(mimeType))
-        return { };
+    if (UNLIKELY(!decoder.isValid()))
+        return std::nullopt;
 
-    RefPtr<FragmentedSharedBuffer> imageData;
-    if (!decoder.decode(imageData))
-        return { };
-
-    return NowPlayingInfoArtwork { WTFMove(src), WTFMove(mimeType), WTFMove(imageData) };
+    return { { WTFMove(*src), WTFMove(*mimeType), WTFMove(*image) } };
 }
 
 struct NowPlayingInfo {

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/encryptedmedia/CDMProxy.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/encryptedmedia/CDMProxy.h
@@ -255,7 +255,7 @@ public:
     // Media player query methods - main thread only.
     const RefPtr<CDMProxy>& proxy() const { ASSERT(isMainThread()); return m_cdmProxy; }
     virtual bool isWaitingForKey() const { ASSERT(isMainThread()); return m_numDecryptorsWaitingForKey > 0; }
-    void setPlayer(MediaPlayer* player) { ASSERT(isMainThread()); m_player = player; }
+    void setPlayer(WeakPtr<MediaPlayer>&& player) { ASSERT(isMainThread()); m_player = WTFMove(player); }
 
     // Proxy methods - must be thread-safe.
     void startedWaitingForKey();
@@ -263,10 +263,7 @@ public:
 
 private:
     RefPtr<CDMProxy> m_cdmProxy;
-    // FIXME: WeakPtr for the m_player? This is accessed from background and main threads, it's
-    // concerning we could be accessing it in the middle of a shutdown on the main-thread, eh?
-    // As a CDMProxy, we ***should*** be turned off before this pointer ever goes bad.
-    MediaPlayer* m_player { nullptr }; // FIXME: MainThread<T>?
+    WeakPtr<MediaPlayer> m_player;
 
     std::atomic<int> m_numDecryptorsWaitingForKey { 0 };
 };

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/FontCache.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/FontCache.h
@@ -195,8 +195,9 @@ public:
     static bool configurePatternForFontDescription(FcPattern*, const FontDescription&);
 #endif
 
-private:
     void invalidate();
+
+private:
     void releaseNoncriticalMemory();
     void platformReleaseNoncriticalMemory();
     void platformInvalidate();

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/MediaUsageInfo.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/MediaUsageInfo.h
@@ -54,7 +54,6 @@ struct MediaUsageInfo {
     bool isMediaDocumentAndNotOwnerElement { false };
     bool pageExplicitlyAllowsElementToAutoplayInline { false };
     bool requiresFullscreenForVideoPlaybackAndFullscreenNotPermitted { false };
-    bool hasHadUserInteractionAndQuirksContainsShouldAutoplayForArbitraryUserGesture { false };
     bool isVideoAndRequiresUserGestureForVideoRateChange { false };
     bool isAudioAndRequiresUserGestureForAudioRateChange { false };
     bool isVideoAndRequiresUserGestureForVideoDueToLowPowerMode { false };
@@ -91,7 +90,6 @@ struct MediaUsageInfo {
             && isMediaDocumentAndNotOwnerElement == other.isMediaDocumentAndNotOwnerElement
             && pageExplicitlyAllowsElementToAutoplayInline == other.pageExplicitlyAllowsElementToAutoplayInline
             && requiresFullscreenForVideoPlaybackAndFullscreenNotPermitted == other.requiresFullscreenForVideoPlaybackAndFullscreenNotPermitted
-            && hasHadUserInteractionAndQuirksContainsShouldAutoplayForArbitraryUserGesture == other.hasHadUserInteractionAndQuirksContainsShouldAutoplayForArbitraryUserGesture
             && isVideoAndRequiresUserGestureForVideoRateChange == other.isVideoAndRequiresUserGestureForVideoRateChange
             && isAudioAndRequiresUserGestureForAudioRateChange == other.isAudioAndRequiresUserGestureForAudioRateChange
             && isVideoAndRequiresUserGestureForVideoDueToLowPowerMode == other.isVideoAndRequiresUserGestureForVideoDueToLowPowerMode
@@ -139,7 +137,6 @@ template<class Encoder> inline void MediaUsageInfo::encode(Encoder& encoder) con
     encoder << isMediaDocumentAndNotOwnerElement;
     encoder << pageExplicitlyAllowsElementToAutoplayInline;
     encoder << requiresFullscreenForVideoPlaybackAndFullscreenNotPermitted;
-    encoder << hasHadUserInteractionAndQuirksContainsShouldAutoplayForArbitraryUserGesture;
     encoder << isVideoAndRequiresUserGestureForVideoRateChange;
     encoder << isAudioAndRequiresUserGestureForAudioRateChange;
     encoder << isVideoAndRequiresUserGestureForVideoDueToLowPowerMode;
@@ -221,9 +218,6 @@ template<class Decoder> inline std::optional<MediaUsageInfo> MediaUsageInfo::dec
         return { };
 
     if (!decoder.decode(info.requiresFullscreenForVideoPlaybackAndFullscreenNotPermitted))
-        return { };
-
-    if (!decoder.decode(info.hasHadUserInteractionAndQuirksContainsShouldAutoplayForArbitraryUserGesture))
         return { };
 
     if (!decoder.decode(info.isVideoAndRequiresUserGestureForVideoRateChange))

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
@@ -137,6 +137,14 @@ MediaTime PlatformTimeRanges::maximumBufferedTime() const
     return m_ranges[length() - 1].m_end;
 }
 
+MediaTime PlatformTimeRanges::minimumBufferedTime() const
+{
+    if (!length())
+        return MediaTime::invalidTime();
+
+    return m_ranges[0].m_start;
+}
+
 void PlatformTimeRanges::add(const MediaTime& start, const MediaTime& end)
 {
 #if !PLATFORM(MAC) // https://bugs.webkit.org/show_bug.cgi?id=180253

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/PlatformTimeRanges.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/PlatformTimeRanges.h
@@ -50,6 +50,7 @@ public:
     MediaTime end(unsigned index, bool& valid) const;
     MediaTime duration(unsigned index) const;
     MediaTime maximumBufferedTime() const;
+    MediaTime minimumBufferedTime() const;
 
     void invert();
     void intersectWith(const PlatformTimeRanges&);

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -54,6 +54,8 @@ namespace WebCore {
 // new current time without triggering this early return.
 // FIXME(135867): Make this gap detection logic less arbitrary.
 static const MediaTime discontinuityTolerance = MediaTime(1, 1);
+static const unsigned evictionAlgorithmInitialTimeChunk = 30000;
+static const unsigned evictionAlgorithmTimeChunkLowThreshold = 3000;
 
 SourceBufferPrivate::SourceBufferPrivate()
     : m_buffered(TimeRanges::create())
@@ -355,6 +357,21 @@ static PlatformTimeRanges removeSamplesFromTrackBuffer(const DecodeOrderSampleMa
     return trackBuffer.removeSamples(samples, logPrefix);
 }
 
+MediaTime SourceBufferPrivate::findPreviousSyncSamplePresentationTime(const MediaTime& time)
+{
+    MediaTime previousSyncSamplePresentationTime = time;
+    for (auto& trackBufferKeyValue : m_trackBufferMap) {
+        TrackBuffer& trackBuffer = trackBufferKeyValue.value;
+        auto sampleIterator = trackBuffer.samples().decodeOrder().findSyncSamplePriorToPresentationTime(time);
+        if (sampleIterator == trackBuffer.samples().decodeOrder().rend())
+            continue;
+        const MediaTime& samplePresentationTime = sampleIterator->first.second;
+        if (samplePresentationTime < time)
+            previousSyncSamplePresentationTime = samplePresentationTime;
+    }
+    return previousSyncSamplePresentationTime;
+}
+
 void SourceBufferPrivate::removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentTime, bool isEnded, CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(start < end);
@@ -401,7 +418,7 @@ void SourceBufferPrivate::removeCodedFrames(const MediaTime& start, const MediaT
     completionHandler();
 }
 
-void SourceBufferPrivate::evictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime, const MediaTime& duration, bool isEnded)
+void SourceBufferPrivate::evictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded)
 {
     // 3.5.13 Coded Frame Eviction Algorithm
     // http://www.w3.org/TR/media-source/#sourcebuffer-coded-frame-eviction
@@ -412,98 +429,98 @@ void SourceBufferPrivate::evictCodedFrames(uint64_t newDataSize, uint64_t maximu
     // This algorithm is run to free up space in this source buffer when new data is appended.
     // 1. Let new data equal the data that is about to be appended to this SourceBuffer.
     // 2. If the buffer full flag equals false, then abort these steps.
-    if (!isBufferFullFor(newDataSize, maximumBufferSize))
+    bool isBufferFull = isBufferFullFor(newDataSize, maximumBufferSize);
+    if (!isBufferFull)
         return;
 
     // 3. Let removal ranges equal a list of presentation time ranges that can be evicted from
     // the presentation to make room for the new data.
 
-    // NOTE: begin by removing data from the beginning of the buffered ranges, 30 seconds at
-    // a time, up to 30 seconds before currentTime.
-    MediaTime thirtySeconds = MediaTime(30, 1);
-    MediaTime maximumRangeEnd = currentTime - thirtySeconds;
+    // NOTE: begin by removing data from the beginning of the buffered ranges, timeChunk seconds at
+    // a time, up to timeChunk seconds before currentTime.
 
 #if !RELEASE_LOG_DISABLED
     uint64_t initialBufferedSize = totalTrackBufferSizeInBytes();
     DEBUG_LOG(LOGIDENTIFIER, "currentTime = ", currentTime, ", require ", initialBufferedSize + newDataSize, " bytes, maximum buffer size is ", maximumBufferSize);
 #endif
 
-    MediaTime rangeStart = MediaTime::invalidTime();
+    const auto& buffered = m_buffered->ranges();
 
-    for (auto& trackBuffer : m_trackBufferMap.values()) {
-        auto iter = trackBuffer.get().samples().presentationOrder().findSampleContainingOrAfterPresentationTime(MediaTime::zeroTime());
-        if (iter != trackBuffer.get().samples().presentationOrder().end()) {
-            MediaTime startTime = iter->first;
-            if (rangeStart.isInvalid() || startTime < rangeStart)
-                rangeStart = startTime;
-        }
-    }
+    unsigned timeChunkAsMilliseconds = evictionAlgorithmInitialTimeChunk;
+    do {
+        const MediaTime timeChunk = MediaTime(timeChunkAsMilliseconds, 1000);
+        const MediaTime maximumRangeEnd = std::min(currentTime - timeChunk, findPreviousSyncSamplePresentationTime(currentTime));
 
-    if (rangeStart.isInvalid())
-        rangeStart = MediaTime::zeroTime();
+        do {
+            MediaTime rangeStart = buffered.minimumBufferedTime();
+            MediaTime rangeEnd = std::min(rangeStart + timeChunk, maximumRangeEnd);
 
-    MediaTime rangeEnd = rangeStart + thirtySeconds;
-    while (rangeStart < maximumRangeEnd) {
+            if (rangeStart >= rangeEnd)
+                break;
+
         // 4. For each range in removal ranges, run the coded frame removal algorithm with start and
         // end equal to the removal range start and end timestamp respectively.
-        removeCodedFrames(rangeStart, std::min(rangeEnd, maximumRangeEnd), currentTime, isEnded);
-        if (!isBufferFullFor(newDataSize, maximumBufferSize)) {
+            removeCodedFrames(rangeStart, rangeEnd, currentTime, isEnded);
+            MediaTime newRangeStart = buffered.minimumBufferedTime();
+            if (newRangeStart == rangeStart)
             break;
-        }
 
-        rangeStart += thirtySeconds;
-        rangeEnd += thirtySeconds;
-    }
+            isBufferFull = isBufferFullFor(newDataSize, maximumBufferSize);
+        } while (isBufferFull);
 
-    if (!isBufferFullFor(newDataSize, maximumBufferSize)) {
+        timeChunkAsMilliseconds /= 2;
+    } while (isBufferFull && timeChunkAsMilliseconds >= evictionAlgorithmTimeChunkLowThreshold);
+
+    if (!isBufferFull) {
 #if !RELEASE_LOG_DISABLED
         DEBUG_LOG(LOGIDENTIFIER, "evicted ", initialBufferedSize - totalTrackBufferSizeInBytes());
 #endif
         return;
     }
 
-    // If there still isn't enough free space and there buffers in time ranges after the current range (ie. there is a gap after
-    // the current buffered range), delete 30 seconds at a time from duration back to the current time range or 30 seconds after
-    // currenTime whichever we hit first.
-    auto buffered = m_buffered->ranges().copyWithEpsilon(timeFudgeFactor());
-    uint64_t currentTimeRange = buffered.findWithEpsilon(currentTime, timeFudgeFactor());
-    if (!buffered.length() || currentTimeRange == buffered.length() - 1) {
+    timeChunkAsMilliseconds = evictionAlgorithmInitialTimeChunk;
+    do {
+        const MediaTime timeChunk = MediaTime(timeChunkAsMilliseconds, 1000);
+        const MediaTime minimumRangeStart = currentTime + timeChunk;
+
+        do {
+            MediaTime rangeEnd = buffered.maximumBufferedTime();
+            MediaTime rangeStart = std::max(minimumRangeStart, rangeEnd - timeChunk);
+
+            if (rangeStart >= rangeEnd)
+                break;
+
+            // Do not evict data from the time range that contains currentTime.
+            size_t currentTimeRange = buffered.find(currentTime);
+            size_t startTimeRange = buffered.find(rangeStart);
+            if (currentTimeRange != notFound && startTimeRange == currentTimeRange) {
+                size_t endTimeRange = buffered.find(rangeEnd);
+                if (endTimeRange == currentTimeRange)
+                    break;
+    }
+
+        // 4. For each range in removal ranges, run the coded frame removal algorithm with start and
+        // end equal to the removal range start and end timestamp respectively.
+            removeCodedFrames(rangeStart, rangeEnd, currentTime, isEnded);
+            MediaTime newRangeEnd = buffered.maximumBufferedTime();
+            if (newRangeEnd == rangeEnd)
+            break;
+
+            isBufferFull = isBufferFullFor(newDataSize, maximumBufferSize);
+        } while (isBufferFull);
+
+        timeChunkAsMilliseconds /= 2;
+    } while (isBufferFull && timeChunkAsMilliseconds >= evictionAlgorithmTimeChunkLowThreshold);
+
+    if (!isBufferFull) {
 #if !RELEASE_LOG_DISABLED
-        ERROR_LOG(LOGIDENTIFIER, "FAILED to free enough after evicting ", initialBufferedSize - totalTrackBufferSizeInBytes());
+        DEBUG_LOG(LOGIDENTIFIER, "evicted ", initialBufferedSize - totalTrackBufferSizeInBytes());
 #endif
         return;
     }
 
-    MediaTime minimumRangeStart =
-        currentTimeRange == notFound ? currentTime + thirtySeconds : std::max(currentTime + thirtySeconds, buffered.end(currentTimeRange));
-
-    rangeEnd = duration;
-    if (!rangeEnd.isFinite()) {
-        rangeEnd = buffered.maximumBufferedTime();
 #if !RELEASE_LOG_DISABLED
-        DEBUG_LOG(LOGIDENTIFIER, "MediaSource duration is not a finite value, using maximum buffered time: ", rangeEnd);
-#endif
-    }
-
-    rangeStart = rangeEnd - thirtySeconds;
-    while (rangeEnd > minimumRangeStart) {
-        // 4. For each range in removal ranges, run the coded frame removal algorithm with start and
-        // end equal to the removal range start and end timestamp respectively.
-        removeCodedFrames(std::max(minimumRangeStart, rangeStart), rangeEnd, currentTime, isEnded);
-
-        if (!isBufferFullFor(newDataSize, maximumBufferSize)) {
-            break;
-        }
-
-        rangeStart -= thirtySeconds;
-        rangeEnd -= thirtySeconds;
-    }
-
-#if !RELEASE_LOG_DISABLED
-    if (isBufferFullFor(newDataSize, maximumBufferSize))
         ERROR_LOG(LOGIDENTIFIER, "FAILED to free enough after evicting ", initialBufferedSize - totalTrackBufferSizeInBytes());
-    else
-        DEBUG_LOG(LOGIDENTIFIER, "evicted ", initialBufferedSize - totalTrackBufferSizeInBytes());
 #endif
 }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -92,7 +92,7 @@ public:
     virtual void setShouldGenerateTimestamps(bool flag) { m_shouldGenerateTimestamps = flag; }
     WEBCORE_EXPORT virtual void updateBufferedFromTrackBuffers(bool sourceIsEnded);
     WEBCORE_EXPORT virtual void removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentMediaTime, bool isEnded, CompletionHandler<void()>&& = [] { });
-    WEBCORE_EXPORT virtual void evictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime, const MediaTime& duration, bool isEnded);
+    WEBCORE_EXPORT virtual void evictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded);
     WEBCORE_EXPORT virtual uint64_t totalTrackBufferSizeInBytes() const;
     WEBCORE_EXPORT virtual void resetTimestampOffsetInTrackBuffers();
     virtual void startChangingType() { m_pendingInitializationSegmentForChangeType = true; }
@@ -164,6 +164,7 @@ private:
     void provideMediaData(TrackBuffer&, const AtomString& trackID);
     void setBufferedDirty(bool);
     void trySignalAllSamplesInTrackEnqueued(TrackBuffer&, const AtomString& trackID);
+    MediaTime findPreviousSyncSamplePresentationTime(const MediaTime&);
 
     bool m_isAttached { false };
     bool m_hasAudio { false };

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -515,9 +515,6 @@ bool WidthIterator::characterCanUseSimplifiedTextMeasuring(UChar character, bool
     switch (character) {
     case newlineCharacter:
     case carriageReturn:
-    case zeroWidthNoBreakSpace:
-    case zeroWidthNonJoiner:
-    case zeroWidthJoiner:
         return true;
     case tabCharacter:
         if (!whitespaceIsCollapsed)
@@ -537,6 +534,9 @@ bool WidthIterator::characterCanUseSimplifiedTextMeasuring(UChar character, bool
     case popDirectionalIsolate:
     case firstStrongIsolate:
     case objectReplacementCharacter:
+    case zeroWidthNoBreakSpace:
+    case zeroWidthNonJoiner:
+    case zeroWidthJoiner:
         return false;
         break;
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/filters/FilterEffect.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/filters/FilterEffect.cpp
@@ -139,7 +139,7 @@ RefPtr<FilterImage> FilterEffect::apply(const Filter& filter, const FilterImageV
         return nullptr;
 
     LOG_WITH_STREAM(Filters, stream
-        << "FilterEffect " << filterName() << " " << this << " apply():"
+        << "FilterEffect " << filterName() << " " << this << " apply(): " << *this
         << "\n  filterPrimitiveSubregion " << primitiveSubregion
         << "\n  absolutePaintRect " << absoluteImageRect
         << "\n  maxEffectRect " << filter.maxEffectRect(primitiveSubregion)

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/filters/FilterFunction.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/filters/FilterFunction.cpp
@@ -28,6 +28,7 @@
 
 #include "ImageBuffer.h"
 #include <wtf/SortedArrayMap.h>
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 
@@ -68,6 +69,11 @@ AtomString FilterFunction::filterName(Type filterType)
 
     ASSERT(namesMap.tryGet(filterType));
     return namesMap.get(filterType, ""_s);
+}
+
+TextStream& operator<<(TextStream& ts, const FilterFunction& filterFunction)
+{
+    return filterFunction.externalRepresentation(ts, FilterRepresentation::Debugging);
 }
 
 } // namespace WebCore

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/filters/FilterFunction.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/filters/FilterFunction.h
@@ -102,6 +102,8 @@ private:
     Type m_filterType;
 };
 
+WEBCORE_EXPORT TextStream& operator<<(TextStream&, const FilterFunction&);
+
 } // namespace WebCore
 
 namespace WTF {

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.cpp
@@ -246,6 +246,28 @@ inline void FEConvolveMatrixSoftwareApplier::setOuterPixels(PaintingData& painti
     }
 }
 
+void FEConvolveMatrixSoftwareApplier::setInteriorPixels(PaintingData& paintingData, int clipRight, int clipBottom)
+{
+    static constexpr int minimalRectDimension = 100 * 100; // Empirical data limit for parallel jobs
+    int stride = 0;
+    if (int iterations = paintingData.width * paintingData.height / minimalRectDimension)
+        stride = clipBottom / iterations;
+
+    if (!stride) {
+        setInteriorPixels(paintingData, clipRight, clipBottom, 0, clipBottom);
+        return;
+    }
+
+        int chunkCount = (clipBottom + stride - 1) / stride;
+
+        ConcurrentWorkQueue::apply(chunkCount, [&](size_t index) {
+        int yStart = stride * index;
+        int yEnd = std::min<int>(yStart + stride, clipBottom);
+
+            setInteriorPixels(paintingData, clipRight, clipBottom, yStart, yEnd);
+        });
+}
+
 void FEConvolveMatrixSoftwareApplier::applyPlatform(PaintingData& paintingData) const
 {
     // Drawing fully covered pixels
@@ -257,22 +279,7 @@ void FEConvolveMatrixSoftwareApplier::applyPlatform(PaintingData& paintingData) 
         setOuterPixels(paintingData, 0, 0, paintingData.width, paintingData.height);
         return;
     }
-
-    static constexpr int minimalRectDimension = (100 * 100); // Empirical data limit for parallel jobs
-
-    if (int iterations = (paintingData.width * paintingData.height) / minimalRectDimension) {
-        int stride = clipBottom / iterations;
-        int chunkCount = (clipBottom + stride - 1) / stride;
-
-        ConcurrentWorkQueue::apply(chunkCount, [&](size_t index) {
-            int yStart = (stride * index);
-            int yEnd = std::min<int>(stride * (index + 1), clipBottom);
-
-            setInteriorPixels(paintingData, clipRight, clipBottom, yStart, yEnd);
-        });
-    } else
-        setInteriorPixels(paintingData, clipRight, clipBottom, 0, clipBottom);
-
+    setInteriorPixels(paintingData, clipRight, clipBottom);
     clipRight += paintingData.targetOffset.x() + 1;
     clipBottom += paintingData.targetOffset.y() + 1;
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h
@@ -67,7 +67,7 @@ private:
 
     static inline void setInteriorPixels(PaintingData&, int clipRight, int clipBottom, int yStart, int yEnd);
     static inline void setOuterPixels(PaintingData&, int x1, int y1, int x2, int y2);
-
+    static void setInteriorPixels(PaintingData&, int clipRight, int clipBottom);
     void applyPlatform(PaintingData&) const;
 };
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngine.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngine.cpp
@@ -37,11 +37,7 @@ namespace Nicosia {
 std::unique_ptr<PaintingEngine> PaintingEngine::create()
 {
 #if (ENABLE(DEVELOPER_MODE) && PLATFORM(WPE)) || USE(GTK4)
-#if USE(GTK4)
-    unsigned numThreads = 4;
-#else
     unsigned numThreads = 0;
-#endif
     if (const char* numThreadsEnv = getenv("WEBKIT_NICOSIA_PAINTING_THREADS")) {
         if (sscanf(numThreadsEnv, "%u", &numThreads) == 1) {
             if (numThreads > 8) {

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -370,7 +370,7 @@ bool RealtimeMediaSource::supportsSizeAndFrameRate(std::optional<IntConstraint> 
     }
 
     // Each of the non-null values is supported individually, see if they all can be applied at the same time.
-    if (!supportsSizeAndFrameRate(WTFMove(width), WTFMove(height), WTFMove(frameRate))) {
+    if (!supportsSizeAndFrameRate(width, height, WTFMove(frameRate))) {
         // Let's try without frame rate constraint if not mandatory.
         if (frameRateConstraint && !frameRateConstraint->isMandatory() && supportsSizeAndFrameRate(WTFMove(width), WTFMove(height), { }))
             return true;

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -52,6 +52,7 @@
 #include <wtf/text/WTFString.h>
 
 #if USE(GSTREAMER)
+#include "GUniquePtrGStreamer.h"
 #include <wtf/glib/GRefPtr.h>
 
 typedef struct _GstEvent GstEvent;
@@ -116,7 +117,7 @@ public:
         virtual void videoFrameAvailable(VideoFrame&, VideoFrameTimeMetadata) = 0;
 
 #if USE(GSTREAMER_WEBRTC)
-        virtual std::optional<uint64_t> queryDecodedVideoFramesCount() { return std::nullopt; }
+        virtual GUniquePtr<GstStructure> queryAdditionalStats() { return nullptr; }
 #endif
     };
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/network/BlobResourceHandle.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/network/BlobResourceHandle.cpp
@@ -155,7 +155,7 @@ void BlobResourceHandle::loadResourceSynchronously(BlobData* blobData, const Res
 }
 
 BlobResourceHandle::BlobResourceHandle(BlobData* blobData, const ResourceRequest& request, ResourceHandleClient* client, bool async)
-    : ResourceHandle { nullptr, request, client, false /* defersLoading */, false /* shouldContentSniff */, true /* shouldContentEncodingSniff */, nullptr /* sourceOrigin */, false /* isMainFrameNavigation */ }
+    : ResourceHandle { nullptr, request, client, false /* defersLoading */, false /* shouldContentSniff */, ContentEncodingSniffingPolicy::Default, nullptr /* sourceOrigin */, false /* isMainFrameNavigation */ }
     , m_blobData { blobData }
     , m_async { async }
 {

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/network/ResourceHandle.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/network/ResourceHandle.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "AuthenticationClient.h"
+#include "ResourceLoaderOptions.h"
 #include "StoredCredentialsPolicy.h"
 #include <wtf/Box.h>
 #include <wtf/MonotonicTime.h>
@@ -95,7 +96,7 @@ class CurlResourceHandleDelegate;
 
 class ResourceHandle : public RefCounted<ResourceHandle>, public AuthenticationClient {
 public:
-    WEBCORE_EXPORT static RefPtr<ResourceHandle> create(NetworkingContext*, const ResourceRequest&, ResourceHandleClient*, bool defersLoading, bool shouldContentSniff, bool shouldContentEncodingSniff, RefPtr<SecurityOrigin>&& sourceOrigin, bool isMainFrameNavigation);
+    WEBCORE_EXPORT static RefPtr<ResourceHandle> create(NetworkingContext*, const ResourceRequest&, ResourceHandleClient*, bool defersLoading, bool shouldContentSniff, ContentEncodingSniffingPolicy, RefPtr<SecurityOrigin>&& sourceOrigin, bool isMainFrameNavigation);
     WEBCORE_EXPORT static void loadResourceSynchronously(NetworkingContext*, const ResourceRequest&, StoredCredentialsPolicy, SecurityOrigin*, ResourceError&, ResourceResponse&, Vector<uint8_t>& data);
     WEBCORE_EXPORT virtual ~ResourceHandle();
 
@@ -155,7 +156,7 @@ public:
     bool shouldContentSniff() const;
     static bool shouldContentSniffURL(const URL&);
 
-    bool shouldContentEncodingSniff() const;
+    ContentEncodingSniffingPolicy contentEncodingSniffingPolicy() const;
 
     WEBCORE_EXPORT static void forceContentSniffing();
 
@@ -214,7 +215,7 @@ public:
     static void registerBuiltinSynchronousLoader(const AtomString& protocol, BuiltinSynchronousLoader);
 
 protected:
-    ResourceHandle(NetworkingContext*, const ResourceRequest&, ResourceHandleClient*, bool defersLoading, bool shouldContentSniff, bool shouldContentEncodingSniff, RefPtr<SecurityOrigin>&& sourceOrigin, bool isMainFrameNavigation);
+    ResourceHandle(NetworkingContext*, const ResourceRequest&, ResourceHandleClient*, bool defersLoading, bool shouldContentSniff, ContentEncodingSniffingPolicy, RefPtr<SecurityOrigin>&& sourceOrigin, bool isMainFrameNavigation);
 
 private:
     enum FailureType {
@@ -240,19 +241,19 @@ private:
 #endif
 
 #if USE(CFURLCONNECTION)
-    void createCFURLConnection(bool shouldUseCredentialStorage, bool shouldContentSniff, bool shouldContentEncodingSniff, RefPtr<SynchronousLoaderMessageQueue>&&, CFDictionaryRef clientProperties);
+    void createCFURLConnection(bool shouldUseCredentialStorage, bool shouldContentSniff, ContentEncodingSniffingPolicy, RefPtr<SynchronousLoaderMessageQueue>&&, CFDictionaryRef clientProperties);
 #endif
 
 #if PLATFORM(MAC)
-    void createNSURLConnection(id delegate, bool shouldUseCredentialStorage, bool shouldContentSniff, bool shouldContentEncodingSniff, SchedulingBehavior);
+    void createNSURLConnection(id delegate, bool shouldUseCredentialStorage, bool shouldContentSniff, ContentEncodingSniffingPolicy, SchedulingBehavior);
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    void createNSURLConnection(id delegate, bool shouldUseCredentialStorage, bool shouldContentSniff, bool shouldContentEncodingSniff, SchedulingBehavior, NSDictionary *connectionProperties);
+    void createNSURLConnection(id delegate, bool shouldUseCredentialStorage, bool shouldContentSniff, ContentEncodingSniffingPolicy, SchedulingBehavior, NSDictionary *connectionProperties);
 #endif
 
 #if PLATFORM(COCOA)
-    NSURLRequest *applySniffingPoliciesIfNeeded(NSURLRequest *, bool shouldContentSniff, bool shouldContentEncodingSniff);
+    NSURLRequest *applySniffingPoliciesIfNeeded(NSURLRequest *, bool shouldContentSniff, ContentEncodingSniffingPolicy);
 #endif
 
 #if USE(CURL)

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/network/ResourceHandleInternal.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/network/ResourceHandleInternal.h
@@ -69,7 +69,7 @@ class ResourceHandleInternal {
     WTF_MAKE_NONCOPYABLE(ResourceHandleInternal);
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(ResourceHandleInternal);
 public:
-    ResourceHandleInternal(ResourceHandle* loader, NetworkingContext* context, const ResourceRequest& request, ResourceHandleClient* client, bool defersLoading, bool shouldContentSniff, bool shouldContentEncodingSniff, RefPtr<SecurityOrigin>&& sourceOrigin, bool isMainFrameNavigation)
+    ResourceHandleInternal(ResourceHandle* loader, NetworkingContext* context, const ResourceRequest& request, ResourceHandleClient* client, bool defersLoading, bool shouldContentSniff, ContentEncodingSniffingPolicy contentEncodingSniffingPolicy, RefPtr<SecurityOrigin>&& sourceOrigin, bool isMainFrameNavigation)
         : m_context(context)
         , m_client(client)
         , m_firstRequest(request)
@@ -77,7 +77,7 @@ public:
         , m_partition(request.cachePartition())
         , m_defersLoading(defersLoading)
         , m_shouldContentSniff(shouldContentSniff)
-        , m_shouldContentEncodingSniff(shouldContentEncodingSniff)
+        , m_contentEncodingSniffingPolicy(contentEncodingSniffingPolicy)
 #if USE(CFURLCONNECTION)
         , m_currentRequest(request)
 #endif
@@ -111,7 +111,7 @@ public:
 
     bool m_defersLoading;
     bool m_shouldContentSniff;
-    bool m_shouldContentEncodingSniff;
+    ContentEncodingSniffingPolicy m_contentEncodingSniffingPolicy;
 #if USE(CFURLCONNECTION)
     RetainPtr<CFURLConnectionRef> m_connection;
     ResourceRequest m_currentRequest;

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/sql/SQLiteDatabase.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/sql/SQLiteDatabase.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2007 Justin Haygood (jhaygood@reaktix.com)
  *
  * Redistribution and use in source and binary forms, with or without
@@ -633,11 +633,13 @@ bool SQLiteDatabase::isAutoCommitOn() const
 
 bool SQLiteDatabase::turnOnIncrementalAutoVacuum()
 {
+    int autoVacuumMode = AutoVacuumNone;
+    {
     auto statement = prepareStatement("PRAGMA auto_vacuum"_s);
     if (!statement)
         return false;
-
-    int autoVacuumMode = statement->columnInt(0);
+        autoVacuumMode = statement->columnInt(0);
+    }
 
     // Check if we got an error while trying to get the value of the auto_vacuum flag.
     // If we got a SQLITE_BUSY error, then there's probably another transaction in

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/text/BidiRunList.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/text/BidiRunList.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2000 Lars Knoll (knoll@kde.org)
- * Copyright (C) 2003, 2004, 2006, 2007, 2008 Apple Inc.  All right reserved.
- * Copyright (C) 2011 Google, Inc.  All rights reserved.
+ * Copyright (C) 2003-2023 Apple Inc.  All right reserved.
+ * Copyright (C) 2011-2014 Google, Inc.  All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -166,7 +166,7 @@ void BidiRunList<Run>::replaceRunWithRuns(Run* toReplace, BidiRunList<Run>& newR
     } else {
         // Find the run just before "toReplace" in the list of runs.
         Run* previousRun = m_firstRun.get();
-        while (previousRun->next() != toReplace)
+        while (previousRun->next() && previousRun->next() != toReplace)
             previousRun = previousRun->next();
         ASSERT(previousRun);
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/CSSFilter.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/CSSFilter.cpp
@@ -47,9 +47,12 @@ RefPtr<CSSFilter> CSSFilter::create(RenderElement& renderer, const FilterOperati
     bool hasFilterThatShouldBeRestrictedBySecurityOrigin = operations.hasFilterThatShouldBeRestrictedBySecurityOrigin();
 
     auto filter = adoptRef(*new CSSFilter(renderingMode, filterScale, clipOperation, hasFilterThatMovesPixels, hasFilterThatShouldBeRestrictedBySecurityOrigin));
-
-    if (!filter->buildFilterFunctions(renderer, operations, targetBoundingBox, destinationContext))
+    if (!filter->buildFilterFunctions(renderer, operations, targetBoundingBox, destinationContext)) {
+        LOG_WITH_STREAM(Filters, stream << "CSSFilter::create: failed to build filters " << operations);
         return nullptr;
+    }
+
+    LOG_WITH_STREAM(Filters, stream << "CSSFilter::create built filter " << filter.get() << " for " << operations);
 
     if (renderingMode == RenderingMode::Accelerated && !filter->supportsAcceleratedRendering())
         filter->setRenderingMode(RenderingMode::Unaccelerated);

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderBlock.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderBlock.cpp
@@ -1069,7 +1069,8 @@ void RenderBlock::layoutPositionedObject(RenderBox& r, bool relayoutChildren, bo
     // If we are paginated or in a line grid, compute a vertical position for our object now.
     // If it's wrong we'll lay out again.
     LayoutUnit oldLogicalTop;
-    bool needsBlockDirectionLocationSetBeforeLayout = r.needsLayout() && view().frameView().layoutContext().layoutState()->needsBlockDirectionLocationSetBeforeLayout();
+    auto* layoutState = view().frameView().layoutContext().layoutState();
+    bool needsBlockDirectionLocationSetBeforeLayout = r.needsLayout() && layoutState && layoutState->needsBlockDirectionLocationSetBeforeLayout();
     if (needsBlockDirectionLocationSetBeforeLayout) {
         if (isHorizontalWritingMode() == r.isHorizontalWritingMode())
             r.updateLogicalHeight();
@@ -1101,7 +1102,7 @@ void RenderBlock::layoutPositionedObject(RenderBox& r, bool relayoutChildren, bo
         r.layoutIfNeeded();
     }
 
-    if (view().frameView().layoutContext().layoutState()->isPaginated() && is<RenderBlockFlow>(*this))
+    if (layoutState && layoutState->isPaginated() && is<RenderBlockFlow>(*this))
         downcast<RenderBlockFlow>(*this).adjustSizeContainmentChildForPagination(r, r.logicalTop());
 }
 
@@ -1132,7 +1133,7 @@ void RenderBlock::markPositionedObjectsForLayout()
 void RenderBlock::markForPaginationRelayoutIfNeeded()
 {
     auto* layoutState = view().frameView().layoutContext().layoutState();
-    if (needsLayout() || !layoutState->isPaginated())
+    if (needsLayout() || !layoutState || !layoutState->isPaginated())
         return;
 
     if (layoutState->pageLogicalHeightChanged() || (layoutState->pageLogicalHeight() && layoutState->pageLogicalOffset(this, logicalTop()) != pageLogicalOffset()))

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderBox.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderBox.cpp
@@ -3259,6 +3259,8 @@ LayoutUnit RenderBox::computeLogicalHeightWithoutLayout() const
 
 std::optional<LayoutUnit> RenderBox::computeLogicalHeightUsing(SizeType heightType, const Length& height, std::optional<LayoutUnit> intrinsicContentHeight) const
 {
+    if (is<RenderReplaced>(this))
+        return computeReplacedLogicalHeightUsing(heightType, height) + borderAndPaddingLogicalHeight();
     if (std::optional<LayoutUnit> logicalHeight = computeContentAndScrollbarLogicalHeightUsing(heightType, height, intrinsicContentHeight))
         return adjustBorderBoxLogicalHeightForBoxSizing(logicalHeight.value());
     return std::nullopt;

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderElement.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderElement.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003, 2006, 2007, 2009, 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2022 Apple Inc. All rights reserved.
  * Copyright (C) 2010, 2012 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -132,7 +132,8 @@ public:
     void setNeedsPositionedMovementLayout(const RenderStyle* oldStyle);
     void setNeedsSimplifiedNormalFlowLayout();
 
-    virtual void paint(PaintInfo&, const LayoutPoint&) = 0;
+    // paintOffset is the offset from the origin of the GraphicsContext at which to paint the current object.
+    virtual void paint(PaintInfo&, const LayoutPoint& paintOffset) = 0;
 
     // inline-block elements paint all phases atomically. This function ensures that. Certain other elements
     // (grid items, flex items) require this behavior as well, and this function exists as a helper for them.

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderImage.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderImage.cpp
@@ -532,7 +532,8 @@ void RenderImage::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOf
             if (!m_altText.isEmpty()) {
                 auto& font = style().fontCascade();
                 auto& fontMetrics = font.metricsOfPrimaryFont();
-                auto textRun = RenderBlock::constructTextRun(document().displayStringModifiedByEncoding(m_altText), style(), ExpansionBehavior::defaultBehavior(), RespectDirection | RespectDirectionOverride);
+                auto encodedDisplayString = document().displayStringModifiedByEncoding(m_altText);
+                auto textRun = RenderBlock::constructTextRun(encodedDisplayString, style(), ExpansionBehavior::defaultBehavior(), RespectDirection | RespectDirectionOverride);
                 auto textWidth = LayoutUnit { font.width(textRun) };
 
                 auto hasRoomForAltText = [&] {

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderLayer.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderLayer.h
@@ -536,6 +536,7 @@ public:
     bool hasVisibleBoxDecorationsOrBackground() const;
     bool hasVisibleBoxDecorations() const;
 
+    void setBehavesAsFixed(bool);
     bool behavesAsFixed() const { return m_behavesAsFixed; }
 
     struct PaintedContentRequest {
@@ -1157,7 +1158,7 @@ private:
     bool paintingInsideReflection() const { return m_paintingInsideReflection; }
     void setPaintingInsideReflection(bool b) { m_paintingInsideReflection = b; }
 
-    void updateFiltersAfterStyleChange();
+    void updateFiltersAfterStyleChange(StyleDifference, const RenderStyle* oldStyle);
     void updateFilterPaintingStrategy();
 
 #if ENABLE(CSS_COMPOSITING)

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3009,6 +3009,9 @@ bool RenderLayerBacking::isUnscaledBitmapOnly() const
         return false;
     }
 
+    if (renderer().style().imageRendering() == ImageRendering::CrispEdges || renderer().style().imageRendering() == ImageRendering::Pixelated)
+        return false;
+
     auto& canvasRenderer = downcast<RenderHTMLCanvas>(renderer());
     if (snappedIntRect(contents).size() == canvasRenderer.canvasElement().size())
         return true;

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -104,6 +104,8 @@ public:
     void setHasHorizontalScrollbar(bool);
     void setHasVerticalScrollbar(bool);
 
+    bool needsAnimatedScroll() const final { return m_isRegisteredForAnimatedScroll; }
+
     OverscrollBehavior horizontalOverscrollBehavior() const final;
     OverscrollBehavior verticalOverscrollBehavior() const final;
 
@@ -241,6 +243,7 @@ public:
 
     std::optional<LayoutRect> updateScrollPosition(const ScrollPositionChangeOptions&, const LayoutRect& revealRect, const LayoutRect& localExposeRect);
     bool isVisibleToHitTesting() const final;
+    void animatedScrollDidEnd() final;
     LayoutRect scrollRectToVisible(const LayoutRect& absoluteRect, const ScrollRectToVisibleOptions&);
     std::optional<LayoutRect> updateScrollPositionForScrollIntoView(const ScrollPositionChangeOptions&, const LayoutRect& revealRect, const LayoutRect& localExposeRect);
 
@@ -269,7 +272,7 @@ private:
     void clearResizer();
 
     void updateScrollbarPresenceAndState(std::optional<bool> hasHorizontalOverflow = std::nullopt, std::optional<bool> hasVerticalOverflow = std::nullopt);
-    void registerScrollableArea();
+    void registerScrollableAreaForAnimatedScroll();
 
 private:
     bool m_scrollDimensionsDirty { true };
@@ -283,6 +286,8 @@ private:
     bool m_requiresScrollPositionReconciliation { false };
     bool m_containsDirtyOverlayScrollbars { false };
     bool m_updatingMarqueePosition { false };
+
+    bool m_isRegisteredForAnimatedScroll { false };
 
     // The width/height of our scrolled area.
     int m_scrollWidth { 0 };

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderListBox.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderListBox.cpp
@@ -395,9 +395,11 @@ void RenderListBox::paintItemForeground(PaintInfo& paintInfo, const LayoutPoint&
     const Vector<HTMLElement*>& listItems = selectElement().listItems();
     HTMLElement* listItemElement = listItems[listIndex];
 
-    auto& itemStyle = *listItemElement->computedStyle();
+    auto itemStyle = listItemElement->computedStyle();
+    if (!itemStyle)
+        return;
 
-    if (itemStyle.visibility() == Visibility::Hidden)
+    if (itemStyle->visibility() == Visibility::Hidden)
         return;
 
     String itemText;
@@ -411,7 +413,7 @@ void RenderListBox::paintItemForeground(PaintInfo& paintInfo, const LayoutPoint&
     if (itemText.isNull())
         return;
 
-    Color textColor = itemStyle.visitedDependentColorWithColorFilter(CSSPropertyColor);
+    Color textColor = itemStyle->visitedDependentColorWithColorFilter(CSSPropertyColor);
     if (isOptionElement && downcast<HTMLOptionElement>(*listItemElement).selected()) {
         if (frame().selection().isFocusedAndActive() && document().focusedElement() == &selectElement())
             textColor = theme().activeListBoxSelectionForegroundColor(styleColorOptions());
@@ -422,10 +424,10 @@ void RenderListBox::paintItemForeground(PaintInfo& paintInfo, const LayoutPoint&
 
     paintInfo.context().setFillColor(textColor);
 
-    TextRun textRun(itemText, 0, 0, ExpansionBehavior::allowRightOnly(), itemStyle.direction(), isOverride(itemStyle.unicodeBidi()), true);
+    TextRun textRun(itemText, 0, 0, ExpansionBehavior::allowRightOnly(), itemStyle->direction(), isOverride(itemStyle->unicodeBidi()), true);
     FontCascade itemFont = style().fontCascade();
     LayoutRect r = itemBoundingBoxRect(paintOffset, listIndex);
-    r.move(itemOffsetForAlignment(textRun, &itemStyle, itemFont, r));
+    r.move(itemOffsetForAlignment(textRun, itemStyle, itemFont, r));
 
     if (is<HTMLOptGroupElement>(*listItemElement)) {
         auto description = itemFont.fontDescription();
@@ -442,7 +444,9 @@ void RenderListBox::paintItemBackground(PaintInfo& paintInfo, const LayoutPoint&
 {
     const Vector<HTMLElement*>& listItems = selectElement().listItems();
     HTMLElement* listItemElement = listItems[listIndex];
-    auto& itemStyle = *listItemElement->computedStyle();
+    auto itemStyle = listItemElement->computedStyle();
+    if (!itemStyle)
+        return;
 
     Color backColor;
     if (is<HTMLOptionElement>(*listItemElement) && downcast<HTMLOptionElement>(*listItemElement).selected()) {
@@ -451,10 +455,10 @@ void RenderListBox::paintItemBackground(PaintInfo& paintInfo, const LayoutPoint&
         else
             backColor = theme().inactiveListBoxSelectionBackgroundColor(styleColorOptions());
     } else
-        backColor = itemStyle.visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor);
+        backColor = itemStyle->visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor);
 
     // Draw the background for this list box item
-    if (itemStyle.visibility() == Visibility::Hidden)
+    if (itemStyle->visibility() == Visibility::Hidden)
         return;
 
     LayoutRect itemRect = itemBoundingBoxRect(paintOffset, listIndex);

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderMultiColumnSet.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderMultiColumnSet.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2012 Apple Inc.  All rights reserved.
+ * Copyright (C) 2012-2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2015 Google Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -239,6 +240,13 @@ LayoutUnit RenderMultiColumnSet::calculateBalancedHeight(bool initial) const
         // Too many forced breaks to allow any implicit breaks. Initial balancing should already
         // have set a good height. There's nothing more we should do.
         return m_computedColumnHeight + sizeContainmentShortage;
+    }
+
+    if (m_computedColumnHeight >= m_maxColumnHeight) {
+        // We cannot stretch any further. We'll just have to live with the overflowing columns. This
+        // typically happens if the max column height is less than the height of the tallest piece
+        // of unbreakable content (e.g. lines).
+        return m_computedColumnHeight;
     }
 
     // If the initial guessed column height wasn't enough, stretch it now. Stretch by the lowest

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderObject.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderObject.h
@@ -3,7 +3,7 @@
  *           (C) 2000 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
  *           (C) 2004 Allan Sandfeld Jensen (kde@carewolf.com)
- * Copyright (C) 2003-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2022 Apple Inc. All rights reserved.
  * Copyright (C) 2009 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -716,8 +716,7 @@ public:
     bool canUpdateSelectionOnRootLineBoxes();
 
     // A single rectangle that encompasses all of the selected objects within this object.  Used to determine the tightest
-    // possible bounding box for the selection.
-    LayoutRect selectionRect(bool clipToVisibleContent = true) { return selectionRectForRepaint(nullptr, clipToVisibleContent); }
+    // possible bounding box for the selection. The rect returned is in the coordinate space of the paint invalidation container's backing.
     virtual LayoutRect selectionRectForRepaint(const RenderLayerModelObject* /*repaintContainer*/, bool /*clipToVisibleContent*/ = true) { return LayoutRect(); }
 
     virtual bool canBeSelectionLeaf() const { return false; }

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderTable.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderTable.cpp
@@ -4,7 +4,8 @@
  *           (C) 1998 Waldo Bastian (bastian@kde.org)
  *           (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2015 Google Inc. All rights reserved.
  * Copyright (C) 2006 Alexey Proskuryakov (ap@nypop.com)
  *
  * This library is free software; you can redistribute it and/or
@@ -417,6 +418,7 @@ void RenderTable::simplifiedNormalFlowLayout()
         caption->layoutIfNeeded();
     for (RenderTableSection* section = topSection(); section; section = sectionBelow(section)) {
         section->layoutIfNeeded();
+        section->layoutRows();
         section->computeOverflowFromCells();
     }
 }

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderTheme.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderTheme.cpp
@@ -87,8 +87,10 @@ RenderTheme::RenderTheme()
 
 ControlPart RenderTheme::adjustAppearanceForElement(RenderStyle& style, const Element* element, ControlPart autoAppearance) const
 {
-    if (!element)
+    if (!element) {
+        style.setEffectiveAppearance(NoControlPart);
         return NoControlPart;
+    }
 
     ControlPart part = style.effectiveAppearance();
     if (part == autoAppearance)

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderTheme.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderTheme.h
@@ -92,9 +92,6 @@ public:
     virtual String mediaControlsFormattedStringForDuration(double) { return String(); }
 #endif // ENABLE(MODERN_MEDIA_CONTROLS)
 #endif // ENABLE(VIDEO)
-#if ENABLE(FULLSCREEN_API)
-    virtual String extraFullScreenStyleSheet() { return String(); }
-#endif
 #if ENABLE(ATTACHMENT_ELEMENT)
     virtual String attachmentStyleSheet() const;
 #endif

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderThemeAdwaita.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderThemeAdwaita.cpp
@@ -341,18 +341,14 @@ bool RenderThemeAdwaita::paintTextField(const RenderObject& renderObject, const 
 
 #if ENABLE(DATALIST_ELEMENT)
     if (is<HTMLInputElement>(renderObject.generatingNode()) && downcast<HTMLInputElement>(*(renderObject.generatingNode())).list()) {
+        auto zoomedArrowSize = menuListButtonArrowSize * renderObject.style().effectiveZoom();
         FloatRect arrowRect = rect;
         if (renderObject.style().direction() == TextDirection::LTR)
-            arrowRect.move(arrowRect.width() - (menuListButtonArrowSize + textFieldBorderSize * 2), (arrowRect.height() / 2.) - (menuListButtonArrowSize / 2.));
+            arrowRect.move(arrowRect.width() - (zoomedArrowSize + textFieldBorderSize * 2), 0);
         else
-            fieldRect.move(textFieldBorderSize * 2, (arrowRect.height() / 2.) - (menuListButtonArrowSize / 2.));
-        arrowRect.setWidth(menuListButtonArrowSize);
-        arrowRect.setHeight(menuListButtonArrowSize);
-        {
-            GraphicsContextStateSaver arrowStateSaver(graphicsContext);
-            graphicsContext.translate(arrowRect.x(), arrowRect.y());
-            ThemeAdwaita::paintArrow(graphicsContext, ThemeAdwaita::ArrowDirection::Down, renderObject.useDarkAppearance());
-        }
+            fieldRect.move(textFieldBorderSize * 2, 0);
+        arrowRect.setWidth(zoomedArrowSize);
+        ThemeAdwaita::paintArrow(graphicsContext, arrowRect, ThemeAdwaita::ArrowDirection::Down, renderObject.useDarkAppearance());
     }
 #endif
 
@@ -404,8 +400,9 @@ LengthBox RenderThemeAdwaita::popupInternalPaddingBox(const RenderStyle& style, 
     if (style.effectiveAppearance() == NoControlPart)
         return { };
 
-    int leftPadding = menuListButtonPadding + (style.direction() == TextDirection::RTL ? menuListButtonArrowSize : 0);
-    int rightPadding = menuListButtonPadding + (style.direction() == TextDirection::LTR ? menuListButtonArrowSize : 0);
+    auto zoomedArrowSize = menuListButtonArrowSize * style.effectiveZoom();
+    int leftPadding = menuListButtonPadding + (style.direction() == TextDirection::RTL ? zoomedArrowSize : 0);
+    int rightPadding = menuListButtonPadding + (style.direction() == TextDirection::LTR ? zoomedArrowSize : 0);
 
     return { menuListButtonPadding, rightPadding, menuListButtonPadding, leftPadding };
 }
@@ -425,19 +422,15 @@ bool RenderThemeAdwaita::paintMenuList(const RenderObject& renderObject, const P
     ControlStates controlStates(states);
     Theme::singleton().paint(ButtonPart, controlStates, graphicsContext, rect, 1., nullptr, 1., 1., false, renderObject.useDarkAppearance(), renderObject.style().effectiveAccentColor());
 
+    auto zoomedArrowSize = menuListButtonArrowSize * renderObject.style().effectiveZoom();
     FloatRect fieldRect = rect;
     fieldRect.inflate(menuListButtonBorderSize);
     if (renderObject.style().direction() == TextDirection::LTR)
-        fieldRect.move(fieldRect.width() - (menuListButtonArrowSize + menuListButtonPadding), (fieldRect.height() / 2.) - (menuListButtonArrowSize / 2));
+        fieldRect.move(fieldRect.width() - (zoomedArrowSize + menuListButtonPadding), 0);
     else
-        fieldRect.move(menuListButtonPadding, (fieldRect.height() / 2.) - (menuListButtonArrowSize / 2));
-    fieldRect.setWidth(menuListButtonArrowSize);
-    fieldRect.setHeight(menuListButtonArrowSize);
-    {
-        GraphicsContextStateSaver arrowStateSaver(graphicsContext);
-        graphicsContext.translate(fieldRect.x(), fieldRect.y());
-        ThemeAdwaita::paintArrow(graphicsContext, ThemeAdwaita::ArrowDirection::Down, renderObject.useDarkAppearance());
-    }
+        fieldRect.move(menuListButtonPadding, 0);
+    fieldRect.setWidth(zoomedArrowSize);
+    ThemeAdwaita::paintArrow(graphicsContext, fieldRect, ThemeAdwaita::ArrowDirection::Down, renderObject.useDarkAppearance());
 
     if (isFocused(renderObject))
         ThemeAdwaita::paintFocus(graphicsContext, rect, menuListButtonFocusOffset, platformFocusRingColor({ }));

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderWidget.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderWidget.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  * Copyright (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -338,8 +338,9 @@ void RenderWidget::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 
     // Paint a partially transparent wash over selected widgets.
     if (isSelected() && !document().printing()) {
-        // FIXME: selectionRect() is in absolute, not painting coordinates.
-        paintInfo.context().fillRect(snappedIntRect(selectionRect()), selectionBackgroundColor());
+        LayoutRect rect = localSelectionRect();
+        rect.moveBy(adjustedPaintOffset);
+        paintInfo.context().fillRect(snappedIntRect(rect), selectionBackgroundColor());
     }
 
     if (hasLayer() && layer()->canResize()) {

--- a/modules/javafx.web/src/main/native/Source/WebCore/style/UserAgentStyle.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/style/UserAgentStyle.cpp
@@ -49,7 +49,6 @@
 #include "MathMLElement.h"
 #include "MediaQueryEvaluator.h"
 #include "Page.h"
-#include "Quirks.h"
 #include "RenderTheme.h"
 #include "RuleSetBuilder.h"
 #include "SVGElement.h"
@@ -230,12 +229,7 @@ void UserAgentStyle::ensureDefaultStyleSheetsForElement(const Element& element)
 
 #if ENABLE(FULLSCREEN_API)
     if (!fullscreenStyleSheet && element.document().fullscreenManager().isFullscreen()) {
-        StringBuilder fullscreenRules;
-        fullscreenRules.appendCharacters(fullscreenUserAgentStyleSheet, sizeof(fullscreenUserAgentStyleSheet));
-        fullscreenRules.append(RenderTheme::singleton().extraFullScreenStyleSheet());
-        if (element.document().quirks().needsBlackFullscreenBackgroundQuirk())
-            fullscreenRules.append(":-webkit-full-screen { background-color: black; }"_s);
-        fullscreenStyleSheet = parseUASheet(fullscreenRules.toString());
+        fullscreenStyleSheet = parseUASheet(StringImpl::createWithoutCopying(fullscreenUserAgentStyleSheet, sizeof(fullscreenUserAgentStyleSheet)));
         addToDefaultStyle(*fullscreenStyleSheet);
     }
 #endif // ENABLE(FULLSCREEN_API)

--- a/modules/javafx.web/src/main/native/Source/WebCore/svg/SVGForeignObjectElement.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/svg/SVGForeignObjectElement.cpp
@@ -113,6 +113,9 @@ bool SVGForeignObjectElement::rendererIsNeeded(const RenderStyle& style)
     // to use parentElement() here. If that changes, this method should be updated to use
     // parentOrShadowHostElement() instead.
     RefPtr ancestor = parentElement();
+    if (!ancestor)
+        return false;
+
     while (ancestor && ancestor->isSVGElement()) {
         if (ancestor->renderer() && ancestor->renderer()->isSVGHiddenContainer())
             return false;

--- a/modules/javafx.web/src/main/native/Source/WebCore/testing/Internals.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/testing/Internals.cpp
@@ -4664,7 +4664,6 @@ ExceptionOr<Internals::MediaUsageState> Internals::mediaUsageState(HTMLMediaElem
         info.value().isMediaDocumentAndNotOwnerElement,
         info.value().pageExplicitlyAllowsElementToAutoplayInline,
         info.value().requiresFullscreenForVideoPlaybackAndFullscreenNotPermitted,
-        info.value().hasHadUserInteractionAndQuirksContainsShouldAutoplayForArbitraryUserGesture,
         info.value().isVideoAndRequiresUserGestureForVideoRateChange,
         info.value().isAudioAndRequiresUserGestureForAudioRateChange,
         info.value().isVideoAndRequiresUserGestureForVideoDueToLowPowerMode,

--- a/modules/javafx.web/src/main/native/Source/WebCore/testing/Internals.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/testing/Internals.h
@@ -1058,7 +1058,6 @@ public:
         bool isMediaDocumentAndNotOwnerElement;
         bool pageExplicitlyAllowsElementToAutoplayInline;
         bool requiresFullscreenForVideoPlaybackAndFullscreenNotPermitted;
-        bool hasHadUserInteractionAndQuirksContainsShouldAutoplayForArbitraryUserGesture;
         bool isVideoAndRequiresUserGestureForVideoRateChange;
         bool isAudioAndRequiresUserGestureForAudioRateChange;
         bool isVideoAndRequiresUserGestureForVideoDueToLowPowerMode;

--- a/modules/javafx.web/src/main/native/Source/WebCore/testing/Internals.idl
+++ b/modules/javafx.web/src/main/native/Source/WebCore/testing/Internals.idl
@@ -177,7 +177,6 @@ enum AutoplayPolicy {
     boolean isMediaDocumentAndNotOwnerElement;
     boolean pageExplicitlyAllowsElementToAutoplayInline;
     boolean requiresFullscreenForVideoPlaybackAndFullscreenNotPermitted;
-    boolean hasHadUserInteractionAndQuirksContainsShouldAutoplayForArbitraryUserGesture;
     boolean isVideoAndRequiresUserGestureForVideoRateChange;
     boolean isAudioAndRequiresUserGestureForAudioRateChange;
     boolean isVideoAndRequiresUserGestureForVideoDueToLowPowerMode;

--- a/modules/javafx.web/src/main/native/Source/WebCore/workers/WorkerScriptLoader.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/workers/WorkerScriptLoader.h
@@ -137,6 +137,7 @@ private:
     bool m_finishing { false };
     bool m_isRedirected { false };
     bool m_isCOEPEnabled { false };
+    bool m_didAddToWorkerScriptLoaderMap { false };
     ResourceResponse::Source m_responseSource { ResourceResponse::Source::Unknown };
     ResourceResponse::Tainting m_responseTainting { ResourceResponse::Tainting::Basic };
     ResourceError m_error;

--- a/modules/javafx.web/src/main/native/Source/WebCore/workers/service/server/RegistrationDatabase.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/workers/service/server/RegistrationDatabase.cpp
@@ -194,7 +194,7 @@ void RegistrationDatabase::postTaskToWorkQueue(Function<void()>&& task)
     });
 }
 
-bool RegistrationDatabase::openSQLiteDatabase(const String& fullFilename)
+void RegistrationDatabase::openSQLiteDatabase(const String& fullFilename, CompletionHandler<void(bool)>&& completionHandler)
 {
     ASSERT(!isMainThread());
     ASSERT(!m_database);
@@ -210,7 +210,7 @@ bool RegistrationDatabase::openSQLiteDatabase(const String& fullFilename)
     if (!m_database->open(fullFilename)) {
         RELEASE_LOG_ERROR(ServiceWorker, "Failed to open Service Worker registration database");
         m_database = nullptr;
-        return false;
+        return completionHandler(false);
     }
 
     // Disable threading checks. We always access the database from our serial WorkQueue. Such accesses
@@ -218,7 +218,8 @@ bool RegistrationDatabase::openSQLiteDatabase(const String& fullFilename)
     // necessary run on the same thread every time (as per GCD documentation).
     m_database->disableThreadingChecks();
 
-    auto doRecoveryAttempt = [&] {
+    auto doRecoveryAttempt = [this, protectedThis = Ref { *this }, fullFilename] {
+        ASSERT(!isMainThread());
         // Delete the database and files. We will try recreating it when flushing changes.
         m_database = nullptr;
         SQLiteFileSystem::deleteDatabaseFile(fullFilename);
@@ -228,16 +229,18 @@ bool RegistrationDatabase::openSQLiteDatabase(const String& fullFilename)
     if (!errorMessage.isNull()) {
         RELEASE_LOG_ERROR(ServiceWorker, "ensureValidRecordsTable failed, reason: %" PUBLIC_LOG_STRING, errorMessage.utf8().data());
         doRecoveryAttempt();
-        return false;
+        return completionHandler(false);
     }
 
-    errorMessage = importRecords();
-    if (!errorMessage.isNull()) {
-        RELEASE_LOG_ERROR(ServiceWorker, "importRecords failed, reason: %" PUBLIC_LOG_STRING, errorMessage.utf8().data());
+    importRecords([completionHandler = WTFMove(completionHandler), doRecoveryAttempt = WTFMove(doRecoveryAttempt)] (String error) mutable {
+        ASSERT(!isMainThread());
+        if (!error.isNull()) {
+            RELEASE_LOG_ERROR(ServiceWorker, "importRecords failed, reason: %" PUBLIC_LOG_STRING, error.utf8().data());
         doRecoveryAttempt();
-        return false;
+            return completionHandler(false);
     }
-    return true;
+        completionHandler(true);
+    });
 }
 
 String RegistrationDatabase::scriptStorageDirectory() const
@@ -258,12 +261,15 @@ void RegistrationDatabase::importRecordsIfNecessary()
     ASSERT(!isMainThread());
 
     if (FileSystem::fileExists(m_databaseFilePath)) {
-        if (!openSQLiteDatabase(m_databaseFilePath)) {
-            callOnMainThread([this, protectedThis = Ref { *this }] {
+        return openSQLiteDatabase(m_databaseFilePath, [this, protectedThis = Ref { *this }] (bool success) mutable {
+            ASSERT(!isMainThread());
+            callOnMainThread([this, protectedThis = WTFMove(protectedThis), success] {
+                if (success)
+                    databaseOpenedAndRecordsImported();
+                else
                 databaseFailedToOpen();
             });
-            return;
-        }
+        });
     }
 
     callOnMainThread([this, protectedThis = Ref { *this }] {
@@ -371,11 +377,11 @@ void RegistrationDatabase::pushChanges(const HashMap<ServiceWorkerRegistrationKe
 void RegistrationDatabase::schedulePushChanges(Vector<ServiceWorkerContextData>&& updatedRegistrations, Vector<ServiceWorkerRegistrationKey>&& removedRegistrations, ShouldRetry shouldRetry, CompletionHandler<void()>&& completionHandler)
 {
     auto pushCounter = shouldRetry == ShouldRetry::Yes ? m_pushCounter : 0;
-    postTaskToWorkQueue([this, protectedThis = Ref { *this }, pushCounter, updatedRegistrations = WTFMove(updatedRegistrations), removedRegistrations = WTFMove(removedRegistrations), completionHandler = WTFMove(completionHandler)]() mutable {
-        bool success = doPushChanges(updatedRegistrations, removedRegistrations);
+    postTaskToWorkQueue([this, protectedThis = Ref { *this }, pushCounter, updatedRegistrations = WTFMove(updatedRegistrations), removedRegistrations = WTFMove(removedRegistrations), completionHandler = WTFMove(completionHandler)] () mutable {
+        doPushChanges(WTFMove(updatedRegistrations), WTFMove(removedRegistrations), [this, protectedThis = WTFMove(protectedThis), pushCounter, completionHandler = WTFMove(completionHandler)] (bool success, Vector<ServiceWorkerContextData>&& updatedRegistrations, Vector<ServiceWorkerRegistrationKey>&& removedRegistrations) mutable {
         if (success) {
-            updatedRegistrations.clear();
-            removedRegistrations.clear();
+                ASSERT(updatedRegistrations.isEmpty());
+                ASSERT(removedRegistrations.isEmpty());
         }
         callOnMainThread([this, protectedThis = WTFMove(protectedThis), success, pushCounter, updatedRegistrations = crossThreadCopy(WTFMove(updatedRegistrations)), removedRegistrations = crossThreadCopy(WTFMove(removedRegistrations)), completionHandler = WTFMove(completionHandler)]() mutable {
             if (!success && (pushCounter + 1) == m_pushCounter) {
@@ -386,6 +392,7 @@ void RegistrationDatabase::schedulePushChanges(Vector<ServiceWorkerContextData>&
             if (completionHandler)
                 completionHandler();
         });
+    });
     });
 }
 
@@ -411,13 +418,21 @@ void RegistrationDatabase::clearAll(CompletionHandler<void()>&& completionHandle
     });
 }
 
-bool RegistrationDatabase::doPushChanges(const Vector<ServiceWorkerContextData>& updatedRegistrations, const Vector<ServiceWorkerRegistrationKey>& removedRegistrations)
+void RegistrationDatabase::doPushChanges(Vector<ServiceWorkerContextData>&& updatedRegistrations, Vector<ServiceWorkerRegistrationKey>&& removedRegistrations, CompletionHandler<void(bool, Vector<ServiceWorkerContextData>&&, Vector<ServiceWorkerRegistrationKey>&&)>&& completionHandler)
 {
     if (!m_database) {
-        openSQLiteDatabase(m_databaseFilePath);
-        if (!m_database)
-            return false;
-    }
+        openSQLiteDatabase(m_databaseFilePath, [this, protectedThis = Ref { *this }, updatedRegistrations = WTFMove(updatedRegistrations), removedRegistrations = WTFMove(removedRegistrations), completionHandler = WTFMove(completionHandler)] (bool success) mutable {
+            if (!success || !m_database)
+                return completionHandler(false, WTFMove(updatedRegistrations), WTFMove(removedRegistrations));
+            doPushChangesWithOpenDatabase(WTFMove(updatedRegistrations), WTFMove(removedRegistrations), WTFMove(completionHandler));
+        });
+    } else
+        doPushChangesWithOpenDatabase(WTFMove(updatedRegistrations), WTFMove(removedRegistrations), WTFMove(completionHandler));
+}
+
+void RegistrationDatabase::doPushChangesWithOpenDatabase(Vector<ServiceWorkerContextData>&& updatedRegistrations, Vector<ServiceWorkerRegistrationKey>&& removedRegistrations, CompletionHandler<void(bool, Vector<ServiceWorkerContextData>&&, Vector<ServiceWorkerRegistrationKey>&&)>&& completionHandler)
+{
+    ASSERT(m_database);
 
     SQLiteTransaction transaction(*m_database);
     transaction.begin();
@@ -425,7 +440,7 @@ bool RegistrationDatabase::doPushChanges(const Vector<ServiceWorkerContextData>&
     auto insertStatement = m_database->prepareStatement("INSERT INTO Records VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"_s);
     if (!insertStatement) {
         RELEASE_LOG_ERROR(ServiceWorker, "Failed to prepare statement to store registration data into records table (%i) - %s", m_database->lastError(), m_database->lastErrorMsg());
-        return false;
+        return completionHandler(false, WTFMove(updatedRegistrations), WTFMove(removedRegistrations));
     }
 
     auto& scriptStorage = this->scriptStorage();
@@ -435,7 +450,7 @@ bool RegistrationDatabase::doPushChanges(const Vector<ServiceWorkerContextData>&
             || deleteStatement->bindText(1, registration.toDatabaseKey()) != SQLITE_OK
             || deleteStatement->step() != SQLITE_DONE) {
             RELEASE_LOG_ERROR(ServiceWorker, "Failed to remove registration data from records table (%i) - %s", m_database->lastError(), m_database->lastErrorMsg());
-            return false;
+            return completionHandler(false, WTFMove(updatedRegistrations), WTFMove(removedRegistrations));
         }
         scriptStorage.clear(registration);
     }
@@ -474,14 +489,14 @@ bool RegistrationDatabase::doPushChanges(const Vector<ServiceWorkerContextData>&
             || insertStatement->bindBlob(14, Span { navigationPreloadStateEncoder.buffer(), navigationPreloadStateEncoder.bufferSize() }) != SQLITE_OK
             || insertStatement->step() != SQLITE_DONE) {
             RELEASE_LOG_ERROR(ServiceWorker, "Failed to store registration data into records table (%i) - %s", m_database->lastError(), m_database->lastErrorMsg());
-            return false;
+            return completionHandler(false, WTFMove(updatedRegistrations), WTFMove(removedRegistrations));
         }
 
         // Save scripts to disk.
         auto mainScript = scriptStorage.store(data.registration.key, data.scriptURL, data.script);
         ASSERT(mainScript);
         if (!mainScript)
-            return false;
+            return completionHandler(false, WTFMove(updatedRegistrations), WTFMove(removedRegistrations));
         MemoryCompactRobinHoodHashMap<URL, ScriptBuffer> importedScripts;
         for (auto& [scriptURL, script] : data.scriptResourceMap) {
             auto importedScript = scriptStorage.store(data.registration.key, scriptURL, script.script);
@@ -497,20 +512,44 @@ bool RegistrationDatabase::doPushChanges(const Vector<ServiceWorkerContextData>&
 
     transaction.commit();
     RELEASE_LOG(ServiceWorker, "Updated ServiceWorker registration database (%zu added/updated registrations and %zu removed registrations", updatedRegistrations.size(), removedRegistrations.size());
-    return true;
+    return completionHandler(true, { }, { });
 }
 
-String RegistrationDatabase::importRecords()
+void RegistrationDatabase::importRecords(CompletionHandler<void(String)>&& completionHandler)
 {
     ASSERT(!isMainThread());
 
     RELEASE_LOG(ServiceWorker, "RegistrationDatabase::importRecords:");
     auto sql = m_database->prepareStatement("SELECT * FROM Records;"_s);
     if (!sql)
-        return makeString("Failed to prepare statement to retrieve registrations from records table (", m_database->lastError(), ") - ", m_database->lastErrorMsg());
+        return completionHandler(makeString("Failed to prepare statement to retrieve registrations from records table (", m_database->lastError(), ") - ", m_database->lastErrorMsg()));
+
+    struct CallbackAggregatorWithErrorString : public ThreadSafeRefCounted<CallbackAggregatorWithErrorString> {
+        static Ref<CallbackAggregatorWithErrorString> create(CompletionHandler<void(String)>&& completionHandler)
+        {
+            return adoptRef(*new CallbackAggregatorWithErrorString(WTFMove(completionHandler)));
+        }
+        void setError(const String& error)
+        {
+            ASSERT(!isMainThread());
+            m_error = error;
+        }
+        ~CallbackAggregatorWithErrorString()
+        {
+            ASSERT(!isMainThread());
+            m_completionHandler(m_error);
+        }
+    private:
+        CallbackAggregatorWithErrorString(CompletionHandler<void(String)>&& completionHandler)
+            : m_completionHandler(WTFMove(completionHandler)) { }
+
+        CompletionHandler<void(String)> m_completionHandler;
+        String m_error;
+    };
+
+    auto aggregator = CallbackAggregatorWithErrorString::create(WTFMove(completionHandler));
 
     int result = sql->step();
-
     for (; result == SQLITE_ROW; result = sql->step()) {
         RELEASE_LOG(ServiceWorker, "RegistrationDatabase::importRecords: Importing a registration from the database");
         auto key = ServiceWorkerRegistrationKey::fromDatabaseKey(sql->columnText(0));
@@ -608,31 +647,37 @@ String RegistrationDatabase::importRecords()
         auto registration = ServiceWorkerRegistrationData { WTFMove(*key), registrationIdentifier, WTFMove(scopeURL), *updateViaCache, lastUpdateCheckTime, std::nullopt, std::nullopt, WTFMove(serviceWorkerData) };
         auto contextData = ServiceWorkerContextData { std::nullopt, WTFMove(registration), workerIdentifier, WTFMove(script), WTFMove(*certificateInfo), WTFMove(*contentSecurityPolicy), WTFMove(*coep), WTFMove(referrerPolicy), WTFMove(scriptURL), *workerType, true, LastNavigationWasAppInitiated::Yes, WTFMove(scriptResourceMap), std::nullopt, WTFMove(*navigationPreloadState) };
 
-        callOnMainThread([protectedThis = Ref { *this }, contextData = WTFMove(contextData).isolatedCopy()]() mutable {
-            protectedThis->addRegistrationToStore(WTFMove(contextData));
+        callOnMainThread([this, protectedThis = Ref { *this }, aggregator, contextData = WTFMove(contextData).isolatedCopy()] () mutable {
+            addRegistrationToStore(WTFMove(contextData), [this, protectedThis = WTFMove(protectedThis), aggregator = WTFMove(aggregator)] () mutable {
+                postTaskToWorkQueue([aggregator = WTFMove(aggregator)] { });
+            });
         });
     }
 
     if (result != SQLITE_DONE)
-        return makeString("Failed to import at least one registration from records table (", m_database->lastError(), ") - ", m_database->lastErrorMsg());
-
-    return { };
+        aggregator->setError(makeString("Failed to import at least one registration from records table (", m_database->lastError(), ") - ", m_database->lastErrorMsg()));
 }
 
-void RegistrationDatabase::addRegistrationToStore(ServiceWorkerContextData&& context)
+void RegistrationDatabase::addRegistrationToStore(ServiceWorkerContextData&& context, CompletionHandler<void()>&& completionHandler)
 {
+    ASSERT(isMainThread());
+
     if (m_store)
-        m_store->addRegistrationFromDatabase(WTFMove(context));
+        m_store->addRegistrationFromDatabase(WTFMove(context), WTFMove(completionHandler));
+    else
+        completionHandler();
 }
 
 void RegistrationDatabase::databaseFailedToOpen()
 {
+    ASSERT(isMainThread());
     if (m_store)
         m_store->databaseFailedToOpen();
 }
 
 void RegistrationDatabase::databaseOpenedAndRecordsImported()
 {
+    ASSERT(isMainThread());
     if (m_store)
         m_store->databaseOpenedAndRecordsImported();
 }

--- a/modules/javafx.web/src/main/native/Source/WebCore/workers/service/server/RegistrationDatabase.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/workers/service/server/RegistrationDatabase.h
@@ -69,17 +69,18 @@ private:
     void postTaskToWorkQueue(Function<void()>&&);
 
     // Methods to be run on the work queue.
-    bool openSQLiteDatabase(const String& fullFilename);
+    void openSQLiteDatabase(const String& fullFilename, CompletionHandler<void(bool)>&&);
     String ensureValidRecordsTable();
-    String importRecords();
+    void importRecords(CompletionHandler<void(String)>&&);
     void importRecordsIfNecessary();
-    bool doPushChanges(const Vector<ServiceWorkerContextData>&, const Vector<ServiceWorkerRegistrationKey>&);
+    void doPushChanges(Vector<ServiceWorkerContextData>&&, Vector<ServiceWorkerRegistrationKey>&&, CompletionHandler<void(bool, Vector<ServiceWorkerContextData>&&, Vector<ServiceWorkerRegistrationKey>&&)>&&);
+    void doPushChangesWithOpenDatabase(Vector<ServiceWorkerContextData>&&, Vector<ServiceWorkerRegistrationKey>&&, CompletionHandler<void(bool, Vector<ServiceWorkerContextData>&&, Vector<ServiceWorkerRegistrationKey>&&)>&&);
     void doClearOrigin(const SecurityOrigin&);
     SWScriptStorage& scriptStorage();
     String scriptStorageDirectory() const;
 
     // Replies to the main thread.
-    void addRegistrationToStore(ServiceWorkerContextData&&);
+    void addRegistrationToStore(ServiceWorkerContextData&&, CompletionHandler<void()>&&);
     void databaseFailedToOpen();
     void databaseOpenedAndRecordsImported();
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/workers/service/server/RegistrationStore.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/workers/service/server/RegistrationStore.cpp
@@ -119,13 +119,14 @@ void RegistrationStore::removeRegistration(const ServiceWorkerRegistrationKey& k
     scheduleDatabasePushIfNecessary();
 }
 
-void RegistrationStore::addRegistrationFromDatabase(ServiceWorkerContextData&& data)
+void RegistrationStore::addRegistrationFromDatabase(ServiceWorkerContextData&& data, CompletionHandler<void()>&& completionHandler)
 {
+    ASSERT(isMainThread());
     ASSERT(!data.registration.key.isEmpty());
     if (data.registration.key.isEmpty())
-        return;
+        return completionHandler();
 
-    m_server.addRegistrationFromStore(WTFMove(data));
+    m_server.addRegistrationFromStore(WTFMove(data), WTFMove(completionHandler));
 }
 
 void RegistrationStore::didSaveWorkerScriptsToDisk(ServiceWorkerIdentifier serviceWorkerIdentifier, ScriptBuffer&& mainScript, MemoryCompactRobinHoodHashMap<URL, ScriptBuffer>&& importedScripts)

--- a/modules/javafx.web/src/main/native/Source/WebCore/workers/service/server/RegistrationStore.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/workers/service/server/RegistrationStore.h
@@ -61,7 +61,7 @@ public:
     void removeRegistration(const ServiceWorkerRegistrationKey&);
 
     // Callbacks from the database
-    void addRegistrationFromDatabase(ServiceWorkerContextData&&);
+    void addRegistrationFromDatabase(ServiceWorkerContextData&&, CompletionHandler<void()>&&);
     void databaseFailedToOpen();
     void databaseOpenedAndRecordsImported();
     void didSaveWorkerScriptsToDisk(ServiceWorkerIdentifier, ScriptBuffer&& mainScript, MemoryCompactRobinHoodHashMap<URL, ScriptBuffer>&& importedScripts);

--- a/modules/javafx.web/src/main/native/Source/WebCore/workers/service/server/SWServer.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/workers/service/server/SWServer.h
@@ -199,7 +199,7 @@ public:
 
     void resolveRegistrationReadyRequests(SWServerRegistration&);
 
-    void addRegistrationFromStore(ServiceWorkerContextData&&);
+    void addRegistrationFromStore(ServiceWorkerContextData&&, CompletionHandler<void()>&&);
     void didSaveWorkerScriptsToDisk(ServiceWorkerIdentifier, ScriptBuffer&& mainScript, MemoryCompactRobinHoodHashMap<URL, ScriptBuffer>&& importedScripts);
     void registrationStoreImportComplete();
     void registrationStoreDatabaseFailedToOpen();

--- a/modules/javafx.web/src/main/native/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -625,7 +625,7 @@ ExceptionOr<void> XMLHttpRequest::createRequest()
     options.initiator = cachedResourceRequestInitiators().xmlhttprequest;
     options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
     options.filteringPolicy = ResponseFilteringPolicy::Enable;
-    options.sniffContentEncoding = ContentEncodingSniffingPolicy::DoNotSniff;
+    options.contentEncodingSniffingPolicy = ContentEncodingSniffingPolicy::Disable;
 
     if (m_timeoutMilliseconds) {
         if (!m_async)
@@ -931,6 +931,13 @@ void XMLHttpRequest::didFinishLoading(ResourceLoaderIdentifier, const NetworkLoa
     if (m_error)
         return;
 
+    // Make sure that didSendData() was called at least one before marking the load as complete
+    // so that a progress events get fired on m_upload.
+    if (m_uploadListenerFlag && m_requestEntityBody && !m_wasDidSendDataCalledForTotalBytes) {
+        auto bodyLength = m_requestEntityBody->lengthInBytes();
+        didSendData(bodyLength, bodyLength);
+    }
+
     if (readyState() < HEADERS_RECEIVED)
         changeState(HEADERS_RECEIVED);
 
@@ -960,6 +967,7 @@ void XMLHttpRequest::didSendData(unsigned long long bytesSent, unsigned long lon
         m_upload->dispatchProgressEvent(eventNames().progressEvent, bytesSent, totalBytesToBeSent);
 
     if (bytesSent == totalBytesToBeSent && !m_uploadComplete) {
+        m_wasDidSendDataCalledForTotalBytes = true;
         m_uploadComplete = true;
         if (m_uploadListenerFlag) {
             m_upload->dispatchProgressEvent(eventNames().loadEvent, bytesSent, totalBytesToBeSent);

--- a/modules/javafx.web/src/main/native/Source/WebCore/xml/XMLHttpRequest.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/xml/XMLHttpRequest.h
@@ -255,6 +255,7 @@ private:
     RefPtr<UserGestureToken> m_userGestureToken;
     TaskCancellationGroup m_pendingAbortEvent;
     std::atomic<bool> m_hasRelevantEventListener;
+    bool m_wasDidSendDataCalledForTotalBytes { false };
 };
 
 inline auto XMLHttpRequest::responseType() const -> ResponseType

--- a/modules/javafx.web/src/main/native/Source/WebKitLegacy/Storage/InProcessIDBServer.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebKitLegacy/Storage/InProcessIDBServer.cpp
@@ -452,9 +452,12 @@ void InProcessIDBServer::databaseConnectionClosed(uint64_t databaseConnectionIde
     });
 }
 
-void InProcessIDBServer::abortOpenAndUpgradeNeeded(uint64_t databaseConnectionIdentifier, const WebCore::IDBResourceIdentifier& transactionIdentifier)
+void InProcessIDBServer::abortOpenAndUpgradeNeeded(uint64_t databaseConnectionIdentifier, const std::optional<WebCore::IDBResourceIdentifier>& transactionIdentifier)
 {
-    dispatchTask([this, protectedThis = Ref { *this }, databaseConnectionIdentifier, transactionIdentifier = transactionIdentifier.isolatedCopy()] {
+    std::optional<WebCore::IDBResourceIdentifier> transactionIdentifierCopy;
+    if (transactionIdentifier)
+        transactionIdentifierCopy = transactionIdentifier->isolatedCopy();
+    dispatchTask([this, protectedThis = Ref { *this }, databaseConnectionIdentifier, transactionIdentifier = WTFMove(transactionIdentifierCopy)] {
         Locker locker { m_serverLock };
         m_server->abortOpenAndUpgradeNeeded(databaseConnectionIdentifier, transactionIdentifier);
     });

--- a/modules/javafx.web/src/main/native/Source/WebKitLegacy/Storage/InProcessIDBServer.h
+++ b/modules/javafx.web/src/main/native/Source/WebKitLegacy/Storage/InProcessIDBServer.h
@@ -84,7 +84,7 @@ public:
     void establishTransaction(uint64_t databaseConnectionIdentifier, const WebCore::IDBTransactionInfo&) final;
     void databaseConnectionPendingClose(uint64_t databaseConnectionIdentifier) final;
     void databaseConnectionClosed(uint64_t databaseConnectionIdentifier) final;
-    void abortOpenAndUpgradeNeeded(uint64_t databaseConnectionIdentifier, const WebCore::IDBResourceIdentifier& transactionIdentifier) final;
+    void abortOpenAndUpgradeNeeded(uint64_t databaseConnectionIdentifier, const std::optional<WebCore::IDBResourceIdentifier>& transactionIdentifier) final;
     void didFireVersionChangeEvent(uint64_t databaseConnectionIdentifier, const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IndexedDB::ConnectionClosedOnBehalfOfServer) final;
     void openDBRequestCancelled(const WebCore::IDBRequestData&) final;
     void getAllDatabaseNamesAndVersions(const WebCore::IDBResourceIdentifier&, const WebCore::ClientOrigin&) final;

--- a/modules/javafx.web/src/main/native/Source/WebKitLegacy/WebCoreSupport/PingHandle.h
+++ b/modules/javafx.web/src/main/native/Source/WebKitLegacy/WebCoreSupport/PingHandle.h
@@ -28,6 +28,7 @@
 #include <WebCore/ResourceError.h>
 #include <WebCore/ResourceHandle.h>
 #include <WebCore/ResourceHandleClient.h>
+#include <WebCore/ResourceLoaderOptions.h>
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/ResourceResponse.h>
 #include <WebCore/SharedBuffer.h>
@@ -50,8 +51,7 @@ public:
     {
         bool defersLoading = false;
         bool shouldContentSniff = false;
-        bool shouldContentEncodingSniff = true;
-        m_handle = WebCore::ResourceHandle::create(networkingContext, request, this, defersLoading, shouldContentSniff, shouldContentEncodingSniff, nullptr, false);
+        m_handle = WebCore::ResourceHandle::create(networkingContext, request, this, defersLoading, shouldContentSniff, WebCore::ContentEncodingSniffingPolicy::Default, nullptr, false);
 
         // If the server never responds, this object will hang around forever.
         // Set a very generous timeout, just in case.

--- a/modules/javafx.web/src/main/native/Source/cmake/FindGI.cmake
+++ b/modules/javafx.web/src/main/native/Source/cmake/FindGI.cmake
@@ -262,6 +262,7 @@ function(GI_INTROSPECT namespace nsversion header)
     foreach (dep IN LISTS opt_DEPENDENCIES)
         if (TARGET "gir-${dep}")
             get_property(dep_gir_path TARGET "gir-${dep}" PROPERTY GI_GIR_PATH)
+            get_property(dep_gir_lib TARGET "gir-${dep}" PROPERTY GI_GIR_LIBRARY)
             if (dep_gir_path)
                 list(APPEND scanner_flags "--include-uninstalled=${dep_gir_path}")
                 list(APPEND gir_deps "${dep_gir_path}")
@@ -270,6 +271,9 @@ function(GI_INTROSPECT namespace nsversion header)
                     "Target '${dep}' listed as a dependency but it has not "
                     "been previously configured with GI_INTROSPECT()"
                 )
+            endif ()
+            if (dep_gir_lib)
+                list(APPEND scanner_flags "--library=${dep_gir_lib}")
             endif ()
         elseif (dep MATCHES "^([a-zA-Z0-9._-]+):([a-z0-9._\\+-]+)$")
             list(APPEND scanner_flags
@@ -337,7 +341,7 @@ function(GI_INTROSPECT namespace nsversion header)
         DEPENDS ${gir_deps} ${gir_srcs}
         VERBATIM
         COMMAND_EXPAND_LISTS
-        COMMAND ${CMAKE_COMMAND} -E env "CC=${CMAKE_C_COMPILER}"
+        COMMAND ${CMAKE_COMMAND} -E env "CC=${CMAKE_C_COMPILER}" "CFLAGS=${CMAKE_C_FLAGS}"
             "${GI_SCANNER_EXE}" --quiet --warn-all --warn-error --no-libtool
             "--output=${gir_path}"
             "--library=$<TARGET_FILE_BASE_NAME:${opt_TARGET}>"
@@ -395,5 +399,6 @@ function(GI_INTROSPECT namespace nsversion header)
 
     # Record in targets to use later on e.g. with gi-docgen.
     set_property(TARGET "gir-${namespace}" PROPERTY GI_GIR_PATH "${gir_path}")
+    set_property(TARGET "gir-${namespace}" PROPERTY GI_GIR_LIBRARY "$<TARGET_FILE_BASE_NAME:${opt_TARGET}>")
     set_property(TARGET "gir-${namespace}" PROPERTY GI_PACKAGE "${opt_PACKAGE}-${nsversion}")
 endfunction()

--- a/modules/javafx.web/src/main/native/Source/cmake/FindWPE.cmake
+++ b/modules/javafx.web/src/main/native/Source/cmake/FindWPE.cmake
@@ -69,16 +69,16 @@ find_library(WPE_LIBRARY
 )
 
 if (WPE_INCLUDE_DIR AND NOT WPE_VERSION)
-    if (EXISTS "${WPE_INCLUDE_DIR}/wpe/version.h")
-        file(READ "${WPE_INCLUDE_DIR}/wpe/version.h" WPE_VERSION_CONTENT)
+    if (EXISTS "${WPE_INCLUDE_DIR}/wpe/libwpe-version.h")
+        file(READ "${WPE_INCLUDE_DIR}/wpe/libwpe-version.h" WPE_VERSION_CONTENT)
 
-        string(REGEX MATCH "#define +WPE_MAJOR_VERSION +\\(([0-9]+)\\)" _dummy "${WPE_VERSION_CONTENT}")
+        string(REGEX MATCH "#define +WPE_MAJOR_VERSION +([0-9]+)" _dummy "${WPE_VERSION_CONTENT}")
         set(WPE_VERSION_MAJOR "${CMAKE_MATCH_1}")
 
-        string(REGEX MATCH "#define +WPE_MINOR_VERSION +\\(([0-9]+)\\)" _dummy "${WPE_VERSION_CONTENT}")
+        string(REGEX MATCH "#define +WPE_MINOR_VERSION +([0-9]+)" _dummy "${WPE_VERSION_CONTENT}")
         set(WPE_VERSION_MINOR "${CMAKE_MATCH_1}")
 
-        string(REGEX MATCH "#define +WPE_MICRO_VERSION +\\(([0-9]+)\\)" _dummy "${WPE_VERSION_CONTENT}")
+        string(REGEX MATCH "#define +WPE_MICRO_VERSION +([0-9]+)" _dummy "${WPE_VERSION_CONTENT}")
         set(WPE_VERSION_PATCH "${CMAKE_MATCH_1}")
 
         set(WPE_VERSION "${WPE_VERSION_MAJOR}.${WPE_VERSION_MINOR}.${WPE_VERSION_PATCH}")

--- a/modules/javafx.web/src/main/native/Source/cmake/GStreamerChecks.cmake
+++ b/modules/javafx.web/src/main/native/Source/cmake/GStreamerChecks.cmake
@@ -32,7 +32,7 @@ if (ENABLE_VIDEO OR ENABLE_WEB_AUDIO)
               list(APPEND GSTREAMER_COMPONENTS transcoder)
           endif ()
 
-          if (USE_GSTREAMER_WEB_RTC)
+          if (USE_GSTREAMER_WEBRTC)
               list(APPEND GSTREAMER_COMPONENTS webrtc)
           endif ()
 

--- a/modules/javafx.web/src/main/native/Source/cmake/OptionsPlayStation.cmake
+++ b/modules/javafx.web/src/main/native/Source/cmake/OptionsPlayStation.cmake
@@ -58,7 +58,7 @@ if (ENABLE_WEBCORE)
     if (WPEBackendPlayStation_FOUND)
         # WPE::libwpe is compiled into the PlayStation backend
         set(WPE_NAMES SceWPE)
-        find_package(WPE REQUIRED)
+        find_package(WPE 1.14.0 REQUIRED)
 
         SET_AND_EXPOSE_TO_BUILD(USE_WPE_BACKEND_PLAYSTATION ON)
 


### PR DESCRIPTION
Clean backport to `jfx20u`. Tested in connection with all other WebKit backports in `jfx-20.0.1` branch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302294](https://bugs.openjdk.org/browse/JDK-8302294): Cherry-pick WebKit 615.1 stabilization fixes


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx20u pull/5/head:pull/5` \
`$ git checkout pull/5`

Update a local copy of the PR: \
`$ git checkout pull/5` \
`$ git pull https://git.openjdk.org/jfx20u pull/5/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5`

View PR using the GUI difftool: \
`$ git pr show -t 5`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx20u/pull/5.diff">https://git.openjdk.org/jfx20u/pull/5.diff</a>

</details>
