### PR TITLE
8302684: Cherry-pick WebKit 615.1 stabilization fixes (2)

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/fetch/FetchHeaders.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/fetch/FetchHeaders.cpp
@@ -50,7 +50,7 @@ static ExceptionOr<bool> canWriteHeader(const String& name, const String& value,
         return Exception { TypeError, "Headers object's guard is 'immutable'"_s };
     if (guard == FetchHeaders::Guard::Request && isForbiddenHeaderName(name))
         return false;
-    if (guard == FetchHeaders::Guard::RequestNoCors && !combinedValue.isEmpty() && !isSimpleHeader(name, combinedValue))
+    if (guard == FetchHeaders::Guard::RequestNoCors && !isSimpleHeader(name, combinedValue))
         return false;
     if (guard == FetchHeaders::Guard::Response && isForbiddenResponseHeaderName(name))
         return false;

--- a/modules/javafx.web/src/main/native/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
@@ -438,7 +438,7 @@ RefPtr<CSSCalcOperationNode> CSSCalcOperationNode::createHypot(Vector<Ref<CSSCal
 {
     auto expectedCategory = commonCategory(values);
 
-    if (expectedCategory == CalculationCategory::Other) {
+    if (!expectedCategory || expectedCategory == CalculationCategory::Other) {
         LOG_WITH_STREAM(Calc, stream << "Failed to create hypot node because unable to determine category from " << prettyPrintNodes(values));
         return nullptr;
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/Document.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/Document.cpp
@@ -6745,7 +6745,7 @@ void Document::postTask(Task&& task)
     callOnMainThread([documentID = identifier(), task = WTFMove(task)]() mutable {
         ASSERT(isMainThread());
 
-        auto* document = allDocumentsMap().get(documentID);
+        RefPtr document = allDocumentsMap().get(documentID);
         if (!document)
             return;
 
@@ -6759,7 +6759,8 @@ void Document::postTask(Task&& task)
 
 void Document::pendingTasksTimerFired()
 {
-    Vector<Task> pendingTasks = WTFMove(m_pendingTasks);
+    Ref protectedThis { *this };
+    auto pendingTasks = std::exchange(m_pendingTasks, Vector<Task> { });
     for (auto& task : pendingTasks)
         task.performTask(*this);
 }

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLInputElement.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLInputElement.cpp
@@ -44,6 +44,7 @@
 #include "Editor.h"
 #include "ElementInlines.h"
 #include "EventNames.h"
+#include "EventLoop.h"
 #include "FileChooser.h"
 #include "FileInputType.h"
 #include "FileList.h"

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLSourceElement.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLSourceElement.cpp
@@ -158,7 +158,7 @@ void HTMLSourceElement::parseAttribute(const QualifiedName& name, const AtomStri
         if (name == mediaAttr)
             m_cachedParsedMediaAttribute = std::nullopt;
         RefPtr parent = parentNode();
-        if (m_shouldCallSourcesChanged)
+        if (m_shouldCallSourcesChanged && parent)
             downcast<HTMLPictureElement>(*parent).sourcesChanged();
     }
 #if ENABLE(MODEL_ELEMENT)

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/ContentFilter.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/ContentFilter.cpp
@@ -317,7 +317,7 @@ URL ContentFilter::url()
 #endif
 }
 
-static const URL& blockedPageURL()
+const URL& ContentFilter::blockedPageURL()
 {
     static NeverDestroyed blockedPageURL = [] () -> URL {
         auto webCoreBundle = CFBundleGetBundleWithIdentifier(CFSTR("com.apple.WebCore"));

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/ContentFilter.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/ContentFilter.h
@@ -79,6 +79,8 @@ public:
     bool isAllowed() const { return m_state == State::Allowed; }
     bool responseReceived() const { return m_responseReceived; }
 
+    WEBCORE_EXPORT static const URL& blockedPageURL();
+
 private:
     using State = PlatformContentFilter::State;
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.cpp
@@ -110,12 +110,12 @@ static HashSet<String, ASCIICaseInsensitiveHash>& mimeTypeCache()
     if (typeListInitialized)
         return cache;
 
-    const char* mimeTypes[] = {
-        "video/holepunch"
+    const ASCIILiteral mimeTypes[] = {
+        "video/holepunch"_s
     };
 
     for (unsigned i = 0; i < (sizeof(mimeTypes) / sizeof(*mimeTypes)); ++i)
-        cache.get().add(String(mimeTypes[i]));
+        cache.get().add(mimeTypes[i]);
 
     typeListInitialized = true;
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngine.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngine.cpp
@@ -37,7 +37,11 @@ namespace Nicosia {
 std::unique_ptr<PaintingEngine> PaintingEngine::create()
 {
 #if (ENABLE(DEVELOPER_MODE) && PLATFORM(WPE)) || USE(GTK4)
+#if USE(GTK4)
+    unsigned numThreads = 1;
+#else
     unsigned numThreads = 0;
+#endif
     if (const char* numThreadsEnv = getenv("WEBKIT_NICOSIA_PAINTING_THREADS")) {
         if (sscanf(numThreadsEnv, "%u", &numThreads) == 1) {
             if (numThreads > 8) {

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/network/NetworkStorageSession.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/network/NetworkStorageSession.cpp
@@ -372,8 +372,11 @@ void NetworkStorageSession::resetAppBoundDomains()
 
 std::optional<Seconds> NetworkStorageSession::clientSideCookieCap(const RegistrableDomain& firstParty, std::optional<PageIdentifier> pageID) const
 {
-    auto domainIterator = m_navigatedToWithLinkDecorationByPrevalentResource.find(*pageID);
 #if ENABLE(JS_COOKIE_CHECKING)
+    if (!pageID)
+        return std::nullopt;
+
+    auto domainIterator = m_navigatedToWithLinkDecorationByPrevalentResource.find(*pageID);
     if (domainIterator != m_navigatedToWithLinkDecorationByPrevalentResource.end() && domainIterator->value == firstParty)
         return m_ageCapForClientSideCookiesForLinkDecorationTargetPage;
 
@@ -382,6 +385,7 @@ std::optional<Seconds> NetworkStorageSession::clientSideCookieCap(const Registra
     if (!m_ageCapForClientSideCookies || !pageID || m_navigatedToWithLinkDecorationByPrevalentResource.isEmpty())
         return m_ageCapForClientSideCookies;
 
+    auto domainIterator = m_navigatedToWithLinkDecorationByPrevalentResource.find(*pageID);
     if (domainIterator == m_navigatedToWithLinkDecorationByPrevalentResource.end())
         return m_ageCapForClientSideCookies;
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/sql/SQLiteTransaction.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/sql/SQLiteTransaction.h
@@ -45,7 +45,7 @@ public:
     void stop();
 
     bool inProgress() const { return m_inProgress; }
-    bool wasRolledBackBySqlite() const;
+    WEBCORE_EXPORT bool wasRolledBackBySqlite() const;
 
     SQLiteDatabase& database() const { return m_db; }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderLayer.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderLayer.cpp
@@ -3262,7 +3262,7 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
 
         // Now walk the sorted list of children with negative z-indices.
         if ((isPaintingScrollingContent && isPaintingOverflowContents) || (!isPaintingScrollingContent && isPaintingCompositedBackground))
-            paintList(negativeZOrderLayers(), currentContext, localPaintingInfo, localPaintFlags);
+            paintList(negativeZOrderLayers(), currentContext, paintingInfo, localPaintFlags);
 
         if (isPaintingCompositedForeground) {
             if (shouldPaintContent) {
@@ -3279,7 +3279,7 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
 
         if (isPaintingCompositedForeground) {
             // Paint any child layers that have overflow.
-            paintList(normalFlowLayers(), currentContext, localPaintingInfo, localPaintFlags);
+            paintList(normalFlowLayers(), currentContext, paintingInfo, localPaintFlags);
 
             // Now walk the sorted list of children with positive z-indices.
             paintList(positiveZOrderLayers(), currentContext, localPaintingInfo, localPaintFlags);

--- a/modules/javafx.web/src/main/native/Source/bmalloc/bmalloc/DebugHeap.cpp
+++ b/modules/javafx.web/src/main/native/Source/bmalloc/bmalloc/DebugHeap.cpp
@@ -122,7 +122,7 @@ void* DebugHeap::malloc(size_t size, FailureAction action)
 
 void* DebugHeap::memalign(size_t alignment, size_t size, FailureAction action)
 {
-    void* result;
+    void* result = nullptr;
     if (posix_memalign(&result, alignment, size))
         RELEASE_BASSERT(action == FailureAction::ReturnNull || result);
     return result;


### PR DESCRIPTION
Clean backport to `jfx20u`. Tested in connection with all other WebKit backports in `jfx-20.0.1` branch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302684](https://bugs.openjdk.org/browse/JDK-8302684): Cherry-pick WebKit 615.1 stabilization fixes (2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx20u pull/6/head:pull/6` \
`$ git checkout pull/6`

Update a local copy of the PR: \
`$ git checkout pull/6` \
`$ git pull https://git.openjdk.org/jfx20u pull/6/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6`

View PR using the GUI difftool: \
`$ git pr show -t 6`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx20u/pull/6.diff">https://git.openjdk.org/jfx20u/pull/6.diff</a>

</details>
