### PR TITLE
8282359: Intermittent WebKit build failure on Windows: C1090: PDB API call failed, error code 23

### DIFF
--- a/modules/javafx.web/src/main/native/Source/cmake/OptionsMSVC.cmake
+++ b/modules/javafx.web/src/main/native/Source/cmake/OptionsMSVC.cmake
@@ -110,11 +110,20 @@ add_compile_options(
 )
 
 if (NOT WTF_CPU_X86)
+    if (PORT STREQUAL "Java")
+    # Suppress creation of pdb files for Release builds
+    # FIXME: Need to re-enable the flag for Debug builds
+    #add_compile_options(/Zi /GS)
+
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /OPT:ICF /OPT:REF")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /OPT:ICF /OPT:REF")
+    else()
     # Create pdb files for debugging purposes, also for Release builds
     add_compile_options(/Zi /GS)
 
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG /OPT:ICF /OPT:REF")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG /OPT:ICF /OPT:REF")
+    endif()
 endif ()
 
 # We do not use exceptions


### PR DESCRIPTION
Clean Backport.This pull request contains a backport of commit [a264435d](https://github.com/openjdk/jfx/commit/a264435dccba6ec386548f76f1ace095d943f4ca) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282359](https://bugs.openjdk.org/browse/JDK-8282359): Intermittent WebKit build failure on Windows: C1090: PDB API call failed, error code 23


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx20u.git pull/12/head:pull/12` \
`$ git checkout pull/12`

Update a local copy of the PR: \
`$ git checkout pull/12` \
`$ git pull https://git.openjdk.org/jfx20u.git pull/12/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12`

View PR using the GUI difftool: \
`$ git pr show -t 12`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx20u/pull/12.diff">https://git.openjdk.org/jfx20u/pull/12.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx20u/pull/12#issuecomment-1502124419)