### PR TITLE
8306450: Create release notes for JavaFX 20.0.1

### DIFF
--- a/doc-files/release-notes-20.0.1.md
+++ b/doc-files/release-notes-20.0.1.md
@@ -10,7 +10,6 @@ These notes document the JavaFX 20.0.1 update release. As such, they complement 
 
 Issue key|Summary|Subcomponent
 ---------|-------|------------
-[JDK-8304008](https://bugs.openjdk.java.net/browse/JDK-8304008)|Update README.md and CONTRIBUTING.md for jfx update repos|other
 [JDK-8299977](https://bugs.openjdk.java.net/browse/JDK-8299977)|Update WebKit to 615.1|web
 [JDK-8300954](https://bugs.openjdk.java.net/browse/JDK-8300954)|HTML default Range input control not rendered|web
 [JDK-8301022](https://bugs.openjdk.java.net/browse/JDK-8301022)|Video distortion is observed while playing youtube video|web

--- a/doc-files/release-notes-20.0.1.md
+++ b/doc-files/release-notes-20.0.1.md
@@ -18,3 +18,10 @@ Issue key|Summary|Subcomponent
 [JDK-8302294](https://bugs.openjdk.java.net/browse/JDK-8302294)|Cherry-pick WebKit 615.1 stabilization fixes|web
 [JDK-8302684](https://bugs.openjdk.java.net/browse/JDK-8302684)|Cherry-pick WebKit 615.1 stabilization fixes (2)|web
 [JDK-8303217](https://bugs.openjdk.java.net/browse/JDK-8303217)|Webview loaded webpage is not showing play, volume related buttons for embeded Audio/Video elements|web
+
+## List of Security fixes
+
+Issue key|Summary|Subcomponent
+---------|-------|------------
+JDK-8299781 (not public)|Improve JFX navigation|web
+JDK-8304177 (not public)|Unable to navigate to relative URLs after fix for JDK-8299781|web

--- a/doc-files/release-notes-20.0.1.md
+++ b/doc-files/release-notes-20.0.1.md
@@ -1,0 +1,20 @@
+# Release Notes for JavaFX 20.0.1
+
+## Introduction
+
+The following notes describe important changes and information about this release. In some cases, the descriptions provide links to additional detailed information about an issue or a change.
+
+These notes document the JavaFX 20.0.1 update release. As such, they complement the [JavaFX 20](https://github.com/openjdk/jfx20u/blob/master/doc-files/release-notes-20.md) release notes.
+
+## List of Fixed Bugs
+
+Issue key|Summary|Subcomponent
+---------|-------|------------
+[JDK-8304008](https://bugs.openjdk.java.net/browse/JDK-8304008)|Update README.md and CONTRIBUTING.md for jfx update repos|other
+[JDK-8299977](https://bugs.openjdk.java.net/browse/JDK-8299977)|Update WebKit to 615.1|web
+[JDK-8300954](https://bugs.openjdk.java.net/browse/JDK-8300954)|HTML default Range input control not rendered|web
+[JDK-8301022](https://bugs.openjdk.java.net/browse/JDK-8301022)|Video distortion is observed while playing youtube video|web
+[JDK-8301712](https://bugs.openjdk.java.net/browse/JDK-8301712)|[linux] Crash on exit from WebKit 615.1|web
+[JDK-8302294](https://bugs.openjdk.java.net/browse/JDK-8302294)|Cherry-pick WebKit 615.1 stabilization fixes|web
+[JDK-8302684](https://bugs.openjdk.java.net/browse/JDK-8302684)|Cherry-pick WebKit 615.1 stabilization fixes (2)|web
+[JDK-8303217](https://bugs.openjdk.java.net/browse/JDK-8303217)|Webview loaded webpage is not showing play, volume related buttons for embeded Audio/Video elements|web

--- a/doc-files/release-notes-20.0.1.md
+++ b/doc-files/release-notes-20.0.1.md
@@ -23,4 +23,4 @@ Issue key|Summary|Subcomponent
 Issue key|Summary|Subcomponent
 ---------|-------|------------
 JDK-8299781 (not public)|Improve JFX navigation|web
-JDK-8304177 (not public)|Unable to navigate to relative URLs after fix for JDK-8299781|web
+JDK-8303501 (not public)|Unable to navigate to relative URLs after fix for JDK-8299781|web


### PR DESCRIPTION
Add release notes for JavaFX 20.0.1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306450](https://bugs.openjdk.org/browse/JDK-8306450): Create release notes for JavaFX 20.0.1


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx20u.git pull/14/head:pull/14` \
`$ git checkout pull/14`

Update a local copy of the PR: \
`$ git checkout pull/14` \
`$ git pull https://git.openjdk.org/jfx20u.git pull/14/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14`

View PR using the GUI difftool: \
`$ git pr show -t 14`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx20u/pull/14.diff">https://git.openjdk.org/jfx20u/pull/14.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx20u/pull/14#issuecomment-1515143125)