### PR TITLE
8312097: Create release notes for JavaFX 20.0.2

### DIFF
--- a/doc-files/release-notes-20.0.2.md
+++ b/doc-files/release-notes-20.0.2.md
@@ -12,3 +12,9 @@ Issue key|Summary|Subcomponent
 ---------|-------|------------
 [JDK-8301009](https://bugs.openjdk.java.net/browse/JDK-8301009)|Update libxml2 to 2.10.3|web
 [JDK-8306115](https://bugs.openjdk.java.net/browse/JDK-8306115)|Update libxml2 to 2.10.4|web
+
+## List of Security fixes
+
+Issue key|Summary|Subcomponent
+---------|-------|------------
+JDK-8304751 (not public)|Improve pipeline layout|graphics

--- a/doc-files/release-notes-20.0.2.md
+++ b/doc-files/release-notes-20.0.2.md
@@ -1,0 +1,14 @@
+# Release Notes for JavaFX 20.0.2
+
+## Introduction
+
+The following notes describe important changes and information about this release. In some cases, the descriptions provide links to additional detailed information about an issue or a change.
+
+These notes document the JavaFX 20.0.2 update release. As such, they complement the [JavaFX 20](https://github.com/openjdk/jfx20u/blob/master/doc-files/release-notes-20.md) and [JavaFX 20.0.1](https://github.com/openjdk/jfx20u/blob/master/doc-files/release-notes-20.0.1.md) release notes.
+
+## List of Fixed Bugs
+
+Issue key|Summary|Subcomponent
+---------|-------|------------
+[JDK-8301009](https://bugs.openjdk.java.net/browse/JDK-8301009)|Update libxml2 to 2.10.3|web
+[JDK-8306115](https://bugs.openjdk.java.net/browse/JDK-8306115)|Update libxml2 to 2.10.4|web


### PR DESCRIPTION
Release notes for JavaFX 20.0.2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312097](https://bugs.openjdk.org/browse/JDK-8312097): Create release notes for JavaFX 20.0.2 (**Task** - P3)


### Reviewers
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)
 * @abhinayagarwal (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx20u.git pull/16/head:pull/16` \
`$ git checkout pull/16`

Update a local copy of the PR: \
`$ git checkout pull/16` \
`$ git pull https://git.openjdk.org/jfx20u.git pull/16/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16`

View PR using the GUI difftool: \
`$ git pr show -t 16`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx20u/pull/16.diff">https://git.openjdk.org/jfx20u/pull/16.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx20u/pull/16#issuecomment-1640326246)